### PR TITLE
refactor: Cluster naming scheme and Cluster.partition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clam"
-version = "0.2.4"
+version = "0.2.5"
 authors = ["Tom Howard <info@tomhoward.codes>", "Najib Ishaq <nishaq@my.uri.edu>", "Noah Daniels <noah_daniels@uri.edu>"]
 edition = "2018"
 

--- a/pyclam/tests/test_functional.py
+++ b/pyclam/tests/test_functional.py
@@ -11,44 +11,41 @@ class TestManifoldFunctional(unittest.TestCase):
     def test_random_no_limits(self):
         # We begin by getting some data and building with no constraints.
         data = np.random.randn(100, 3)
-        m = Manifold(data, 'euclidean')
-        m.build()
+        manifold = Manifold(data, 'euclidean').build()
         # With no constraints, clusters should be singletons.
-        self.assertEqual(data.shape[0], m.graph.population)
-        self.assertEqual(1, len(m.find_clusters(data[0], 0., -1)))
-        self.assertEqual(1, len(m.find_points(data[0], 0.)))
+        self.assertEqual(data.shape[0], manifold.graph.population)
+        self.assertEqual(1, len(manifold.find_clusters(data[0], 0., -1)))
+        self.assertEqual(1, len(manifold.find_points(data[0], 0.)))
+        self.assertEqual(data.shape[0], manifold.layers[-1].cardinality)
         return
 
     def test_random_large(self):
         data = np.random.randn(1000, 3)
-        m = Manifold(data, 'euclidean')
-        m.build(MinPoints(10))
+        manifold = Manifold(data, 'euclidean').build(MinPoints(10))
         for _ in range(10):
             point = int(np.random.choice(3))
-            linear_results = linear_search(data[point], 0.5, data, m.metric)
-            self.assertEqual(len(linear_results), len(m.find_points(data[point], 0.5)))
+            linear_results = linear_search(data[point], 0.5, data, manifold.metric)
+            self.assertEqual(len(linear_results), len(manifold.find_points(data[point], 0.5)))
         return
 
     def test_all_same(self):
         # A bit simpler, every point is the same.
         data = np.ones((1000, 3))
-        m = Manifold(data, 'euclidean')
-        m.build()
+        manifold = Manifold(data, 'euclidean').build()
         # There should only ever be one cluster here.
-        self.assertEqual(1, len(m.layers))
-        m.build_tree()
+        self.assertEqual(1, len(manifold.layers))
+        manifold.build_tree()
         # Even after explicit deepen calls.
-        self.assertEqual(1, len(m.layers))
-        self.assertEqual(1, len(m.find_clusters(np.asarray([1, 1, 1]), 0.0, -1)))
+        self.assertEqual(1, len(manifold.layers))
+        self.assertEqual(1, len(manifold.find_clusters(np.asarray([1, 1, 1]), 0.0, -1)))
         # And, we should get all 1000 points back for any of the data.
-        self.assertEqual(1000, len(m.find_points(data[0], 0.0)))
+        self.assertEqual(1000, len(manifold.find_points(data[0], 0.0)))
         return
 
     def test_two_points_with_dups(self):
         # Here we have two distinct clusters.
         data = np.concatenate([np.ones((500, 2)) * -2, np.ones((500, 2)) * 2])
-        m = Manifold(data, 'euclidean')
+        manifold = Manifold(data, 'euclidean').build()
         # We expect building to stop with two clusters.
-        m.build()
-        self.assertEqual(2, m.graph.cardinality, f'Expected 2 clusters, got {m.graph.cardinality}')
+        self.assertEqual(2, manifold.graph.cardinality, f'Expected 2 clusters, got {manifold.graph.cardinality}')
         return

--- a/pyclam/tests/test_graph.py
+++ b/pyclam/tests/test_graph.py
@@ -66,8 +66,8 @@ class TestGraph(unittest.TestCase):
 
     def test_subgraphs(self):
         subgraphs = self.manifold.graph.subgraphs
-        [self.assertIsInstance(g, Graph) for g in subgraphs]
-        self.assertEqual(sum(g.cardinality for g in subgraphs), self.manifold.graph.cardinality)
+        [self.assertIsInstance(subgraph, Graph) for subgraph in subgraphs]
+        self.assertEqual(sum(subgraph.cardinality for subgraph in subgraphs), self.manifold.graph.cardinality)
         return
 
     def test_clear_cache(self):
@@ -79,22 +79,20 @@ class TestGraph(unittest.TestCase):
         return
 
     def test_bft(self):
-        g = self.manifold.graph.bft(next(iter(self.manifold.graph)))
-        self.assertGreater(len(g), 0)
-        self.assertLessEqual(len(g), self.manifold.graph.cardinality)
+        visited = self.manifold.graph.bft(next(iter(self.manifold.graph)))
+        self.assertGreater(len(visited), 0)
+        self.assertLessEqual(len(visited), self.manifold.graph.cardinality)
         return
 
     def test_dft(self):
-        g = self.manifold.graph.dft(next(iter(self.manifold.graph)))
-        self.assertGreater(len(g), 0)
-        self.assertLessEqual(len(g), self.manifold.graph.cardinality)
+        visited = self.manifold.graph.dft(next(iter(self.manifold.graph)))
+        self.assertGreater(len(visited), 0)
+        self.assertLessEqual(len(visited), self.manifold.graph.cardinality)
         return
 
     def test_random_walks(self):
-        # manifold = self.manifold.build(MaxDepth(10))
-        g = self.manifold.graph
-        results = g.random_walks(list(g.clusters), 250)
-        print(sum(results.values()))
+        graph = self.manifold.graph
+        results = graph.random_walks(list(graph.clusters), 100)
         self.assertGreater(len(results), 0)
         [self.assertGreaterEqual(v, 0) for k, v in results.items()]
         return

--- a/pyclam/tests/test_manifold.py
+++ b/pyclam/tests/test_manifold.py
@@ -108,11 +108,11 @@ class TestManifold(unittest.TestCase):
         return
 
     def test_ancestry(self):
-        name = '11'
+        name = '0101'
         lineage = self.manifold.ancestry(name)
-        [self.assertEqual(name[:i], l.name) for i, l in enumerate(lineage)]
+        [self.assertEqual(name[:len(l.name)], l.name) for i, l in enumerate(lineage)]
         lineage = self.manifold.ancestry(lineage[-1])
-        [self.assertEqual(name[:i], l.name) for i, l in enumerate(lineage)]
+        [self.assertEqual(name[:len(l.name)], l.name) for i, l in enumerate(lineage)]
         return
 
     def test_select(self):
@@ -121,9 +121,9 @@ class TestManifold(unittest.TestCase):
             self.assertIsInstance(self.manifold.select(cluster.name), Cluster)
         else:
             with self.assertRaises(ValueError):
-                self.manifold.select(cluster.name + '1')
+                self.manifold.select(cluster.name + '01')
             with self.assertRaises(ValueError):
-                self.manifold.select(cluster.name + '111111111111111111111111111')
+                self.manifold.select(cluster.name + '01110110')
         return
 
     def test_optimal_in_graph(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [tool.poetry]
 name = "pyclam"
-version = "0.2.4"
+version = "0.2.5"
 description = "Clustered Learning of Approximate Manifolds"
-authors = ["Tom <info@tomhoward.codes>", "Najib <najib_ishaq@zoho.com>"]
+authors = ["Tom Howard <info@tomhoward.codes>", "Najib Ishaq <najib_ishaq@zoho.com>", "Noah Daniels <noah_daniels@uri.edu>"]
 license = "MIT"
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
Cluster.partition can now truly deal with an arbitrary number of poles.
Cluster naming scheme has been updated to deal with arbitrary arity of the tree.