### PR TITLE
Feature/manifold dot file

### DIFF
--- a/pyclam/tests/test_graph.py
+++ b/pyclam/tests/test_graph.py
@@ -119,3 +119,8 @@ class TestGraph(unittest.TestCase):
 
             self.assertEqual(0, len(graph.cache), f'\n4. Graph cache had some elements. {[k for k in graph.cache.keys()]}. iter {i}')
         return
+
+    @unittest.skip
+    def test_dot_file(self):
+        # TODO
+        pass


### PR DESCRIPTION
The function get_dot_file_string() has been added to the manifold class in Manifold.py, which returns a string that can be written on a dot file to produce a graph of the manifold. There are edges between parent and child clusters, as well as edges between overlapping clusters that are on the same level of the manifold.