### PR TITLE
feat: integrated CHESS module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clam"
-version = "0.2.9"
+version = "0.2.10"
 authors = ["Tom Howard <info@tomhoward.codes>", "Najib Ishaq <nishaq@my.uri.edu>", "Noah Daniels <noah_daniels@uri.edu>"]
 edition = "2018"
 

--- a/pyclam/__init__.py
+++ b/pyclam/__init__.py
@@ -1,4 +1,6 @@
+from . import chaoda
 from . import criterion
-from . import types
 from . import datasets
+from . import types
+from .chess import Search
 from .manifold import Manifold, Graph, Cluster, Edge

--- a/pyclam/chaoda.py
+++ b/pyclam/chaoda.py
@@ -6,7 +6,7 @@ from typing import List, Dict, Set
 import numpy as np
 from scipy.special import erf
 
-from pyclam import Graph, Cluster, Edge
+from pyclam.manifold import Graph, Cluster, Edge
 
 
 def _catch_normalization_mode(mode: str) -> None:

--- a/pyclam/chess.py
+++ b/pyclam/chess.py
@@ -1,0 +1,186 @@
+from typing import Dict, Optional, List, Set, Tuple
+
+import numpy as np
+
+import pyclam.criterion as criterion
+from pyclam.manifold import Manifold, Cluster
+from pyclam.types import Data, Metric, Datum
+
+ClusterResults = Dict[Cluster, float]
+Results = Dict[int, float]
+
+
+class Search:
+    def __init__(self, data: Data, metric: Metric):
+        self.data: Data = data
+        self.metric: Metric = metric
+        self.manifold: Manifold = Manifold(self.data, self.metric)
+        self.distance = self.manifold.distance
+        self.root: Cluster = self.manifold.root
+
+    @property
+    def depth(self) -> int:
+        """ returns the depth of the search tree. """
+        return self.manifold.depth
+
+    def build(self, *, max_depth: Optional[int] = None) -> 'Search':
+        """ Builds the search tree upto leaves, or an optional maximum depth.
+
+        This method can be called repeatedly, with higher depth values, to further increase the depth of the tree.
+
+        :param max_depth: optional maximum depth of search tree
+        :return: the modified Search object.
+        """
+        if max_depth is None:
+            self.manifold.build(criterion.Layer[-1])
+        elif max_depth < 1:
+            raise ValueError(f'Expected a positive integer for max_depth. Got {max_depth} instead.')
+        elif max_depth > self.depth:
+            self.manifold.build_tree(criterion.MaxDepth(max_depth), criterion.Layer(-1))
+        return self
+
+    def rnn(self, query: Datum, radius: float, *, max_depth: Optional[int] = None) -> Results:
+        """ Performs rho-nearest neighbors search around query with given radius.
+
+        :param query: point around which to search.
+        :param radius: distance from query within which te return all hits.
+        :param max_depth: optional maximum search depth.
+        :return: dictionary of index-of-hit -> distance-to-hit.
+        """
+        candidate_clusters: ClusterResults = self._tree_search(query, radius, self.root, max_depth=max_depth)
+        return self._leaf_search(query, radius, candidate_clusters)
+
+    def knn(self, query: Datum, k: int, *, max_depth: Optional[int] = None) -> Results:
+        """ Performs k-nearest neighbors search around query.
+
+        :param query: point around which to look.
+        :param k: number of closest neighbors to look for.
+        :param max_depth: optional maximum search depth.
+        :return: dictionary of index-of-neighbor -> distance-to-neighbor.
+        """
+        if k < 1:
+            raise ValueError(f'k must be a positive integer. Got {k}')
+
+        radius: float = (k / self.root.cardinality) * self.root.radius
+        assert radius > 0, f'expected a positive value for radius. Got {radius:.2e} instead.'
+
+        hits: Results = self.rnn(query, radius, max_depth=max_depth)
+        while len(hits) == 0:  # make sure to have non-zero hits
+            radius *= 2
+            hits = self.rnn(query, radius, max_depth=max_depth)
+
+        while len(hits) < k:  # make sure to have more at least k hits
+            # calculate lfd in ball around query
+            if len(hits) == 1:
+                lfd = 1
+            else:
+                half_count = len([point for point, distance in hits.items() if distance <= radius / 2])
+                lfd = 1 if half_count == 0 else np.log2(len(hits) / half_count)
+
+            # increase radius as guided by lfd
+            factor = (k / len(hits)) ** (1 / lfd)
+            assert factor > 1, f'expected factor to be greater than 1. Got {factor:.2e} instead.'
+            radius *= factor
+
+            # rerun rnn search
+            hits = self.rnn(query, radius, max_depth=max_depth)
+
+        # sort hits in non-decreasing order of distance to query
+        results: List[Tuple[float, int]] = list(sorted([(distance, point) for point, distance in hits.items()]))
+        return {point: distance for distance, point in results[:k]}
+
+    def _check_shape(self, points: np.ndarray) -> None:
+        if len(points.shape) != len(self.data.shape):
+            raise ValueError(f'wrong number of dimensions in shape. Expected {len(self.data.shape)}, but got {len(points.shape)}')
+        elif points.shape[1:] != self.data.shape[1:]:
+            raise ValueError(f'wrong dimensionality of points. Expected {self.data.shape[1:]}, but got {points.shape[1:]}')
+        else:
+            return
+
+    def _parse_query(self, query: Datum) -> np.ndarray:
+        if isinstance(query, int):
+            query: np.ndarray = np.asarray([self.data[query]])
+        query = np.expand_dims(query, 0)
+        self._check_shape(query)
+        return query
+
+    def _tree_search(self, query: Datum, radius: float, start: Cluster, *, max_depth: Optional[int] = None) -> ClusterResults:
+        """ Performs tree-search for the query, starting at the given cluster.
+
+        :param query: point around which to search.
+        :param radius: distance from point within which to look.
+        :param start: starting cluster for search.
+        :param max_depth: optional maximum search depth starting at Cluster.
+        :return: dictionary of cluster -> distance between query and cluster center
+        """
+        if max_depth is None:
+            max_depth = self.manifold.depth
+        elif max_depth < 0:
+            raise ValueError(f'max_depth must be a non-negative integer. Got {max_depth} instead.')
+        else:
+            max_depth = min(self.manifold.depth, start.depth + max_depth)
+
+        query = self._parse_query(query)
+        candidates: ClusterResults = {start: -1}
+        hits: ClusterResults = dict()
+        for depth in range(start.depth, max_depth + 1):
+            if len(candidates) == 0:
+                break
+            # find distances to centers of candidate clusters
+            clusters: List[Cluster] = list(candidates.keys())
+            centers: np.ndarray = np.asarray([cluster.center for cluster in clusters])
+            self._check_shape(centers)
+            distances: List[float] = list(self.distance(query, centers)[0])
+
+            candidates = {  # filter out clusters that are too far away
+                cluster: distance for cluster, distance in zip(clusters, distances)
+                if distance <= (radius + cluster.radius)
+            }
+            subsumed: Set[Cluster] = {  # set of clusters that lie completely within radius of query
+                cluster for cluster, distance in candidates.items()
+                if (distance + cluster.radius) <= radius
+            }
+            hits.update({  # add subsumed clusters to hits, singletons should already be included here
+                cluster: distance
+                for cluster, distance in candidates.items()
+                if cluster in subsumed
+            })
+            hits.update({  # add non-singleton leaves to hits
+                cluster: distance
+                for cluster, distance in candidates.items()
+                if (cluster not in subsumed) and (len(cluster.children) == 0)
+            })
+            candidates = {  # expand search to children
+                child: -1
+                for cluster in candidates.keys()
+                for child in cluster.children
+                if cluster not in hits
+            }
+
+        return hits
+
+    def _leaf_search(self, query: Datum, radius: float, clusters: ClusterResults) -> Results:
+        """ Performs leaf search for query on given clusters.
+
+        :param query: point around which to look.
+        :param radius: distance from point within which to look.
+        :param clusters: candidate clusters which need to be exhaustively searched.
+        :return: dictionary of index-of-hit -> distance-to-hit.
+        """
+        query = self._parse_query(query)
+
+        # initialize hits
+        hits: Results = dict()
+
+        # get indices of all points in candidate clusters
+        argpoints: List[int] = [point for cluster in clusters for point in cluster.argpoints]
+
+        # get distances from query to candidate points
+        points: np.ndarray = self.data[argpoints]
+        self._check_shape(points)
+        distances: List[float] = list(self.distance(query, points)[0])
+
+        # update hits with points within radius of query
+        hits.update({point: distance for point, distance in zip(argpoints, distances) if distance <= radius})
+
+        return hits

--- a/pyclam/criterion.py
+++ b/pyclam/criterion.py
@@ -118,13 +118,13 @@ class Layer(SelectionCriterion):
     """ Selects the layer at the specified depth.
     """
     def __init__(self, depth: int):
-        if depth <= 0:
-            raise ValueError(f'expected a positive depth. got: {depth}')
+        if depth < -1:
+            raise ValueError(f'expected a \'-1\' or a non-negative depth. got: {depth}')
         self.depth = depth
 
     def __call__(self, root: Cluster) -> Set[Cluster]:
         manifold: Manifold = root.manifold
-        if manifold.depth <= self.depth:
+        if (self.depth == -1) or (manifold.depth <= self.depth):
             return {cluster for cluster in manifold.layers[-1].clusters}
         else:
             return {cluster for cluster in manifold.layers[self.depth].clusters}

--- a/pyclam/tests/test_cluster.py
+++ b/pyclam/tests/test_cluster.py
@@ -2,7 +2,7 @@ import unittest
 
 import numpy as np
 
-from pyclam import criterion, datasets, Manifold, Cluster
+from pyclam import datasets, Manifold, Cluster
 from pyclam.manifold import BATCH_SIZE
 
 
@@ -129,30 +129,6 @@ class TestCluster(unittest.TestCase):
     def test_clear_cache(self):
         self.cluster.clear_cache()
         self.assertNotIn('argsamples', self.cluster.cache)
-        return
-
-    def test_tree_search(self):
-        np.random.seed(42)
-        data, labels = datasets.line()
-        manifold = Manifold(data, 'euclidean')
-        manifold.build_tree(criterion.MinPoints(10), criterion.MaxDepth(5))
-        # Finding points that are in data.
-        for depth, layer in enumerate(manifold.layers):
-            for cluster in layer.clusters:
-                linear = set([c for c in layer if c.overlaps(cluster.medoid, cluster.radius)])
-                tree = set(next(iter(manifold.layers[0])).tree_search(cluster.medoid, cluster.radius, cluster.depth).keys())
-                self.assertSetEqual(set(), tree - linear)
-                for d in range(depth, 0, -1):
-                    parents = set([manifold.select(cluster.name[:-1]) for cluster in linear])
-                    for parent in parents:
-                        results = parent.tree_search(cluster.medoid, cluster.radius, parent.depth)
-                        self.assertIn(parent, results, msg=f'\n{parent.name} not in {[c.name for c in results]}. '
-                                                           f'got {len(results)} hits.')
-        # Attempting to find points that *may* be in the data
-        results = manifold.root.tree_search(point=np.asarray([0, 1]), radius=0., depth=-1)
-        self.assertEqual(0, len(results))
-        with self.assertRaises(ValueError):
-            _ = manifold.root.tree_search(point=np.asarray([0, 1]), radius=0., depth=-5)
         return
 
     def test_partition(self):

--- a/pyclam/tests/test_functional.py
+++ b/pyclam/tests/test_functional.py
@@ -2,34 +2,37 @@ import unittest
 
 import numpy as np
 
-from pyclam import criterion, Manifold
-from pyclam.tests.utils import linear_search
+from pyclam import Manifold
 
 
+# TODO: Should we scrap this file?
 class TestManifoldFunctional(unittest.TestCase):
     def test_random_no_limits(self):
         # We begin by getting some data and building with no constraints.
         data = np.random.randn(100, 3)
         manifold = Manifold(data, 'euclidean').build()
-        # With no constraints, clusters should be singletons.
-        for graph in manifold.graphs:
-            self.assertEqual(data.shape[0], graph.population, f'expected {data.shape[0]} points in the graph. Got {graph.cardinality} instead.')
-        self.assertEqual(1, len(manifold.find_clusters(data[0], 0., -1)))
-        self.assertEqual(1, len(manifold.find_points(data[0], 0.)))
-        self.assertEqual(data.shape[0], manifold.layers[-1].cardinality)
+
+        for layer in manifold.layers:  # each layer must have the same number of points
+            self.assertEqual(data.shape[0], layer.population, f'expected {data.shape[0]} points in the graph. '
+                                                              f'Got {layer.cardinality} instead.')
+
+        for leaf in manifold.layers[-1]:  # With no constraints, clusters should be singletons.
+            self.assertEqual(1, leaf.cardinality, f'expected each leaf to be a singleton. '
+                                                  f'Got leaf {str(leaf)} with {leaf.cardinality} points')
         return
 
-    def test_random_large(self):
-        data = np.random.randn(1000, 3)
-        manifold = Manifold(data, 'euclidean').build(
-            criterion.MaxDepth(10),
-            criterion.LFDRange(60, 50),
-        )
-        for _ in range(10):
-            point = int(np.random.choice(3))
-            linear_results = linear_search(data[point], 0.5, data, manifold.metric)
-            self.assertEqual(len(linear_results), len(manifold.find_points(data[point], 0.5)))
-        return
+    # TODO: Is this test even needed here?
+    # def test_random_large(self):
+    #     data = np.random.randn(1000, 3)
+    #     manifold = Manifold(data, 'euclidean').build(
+    #         criterion.MaxDepth(10),
+    #         criterion.LFDRange(60, 50),
+    #     )
+    #     for _ in range(10):
+    #         point = int(np.random.choice(3))
+    #         linear_results = linear_search(data[point], 0.5, data, manifold.metric)
+    #         # self.assertEqual(len(linear_results), len(manifold.find_points(data[point], 0.5)))
+    #     return
 
     def test_all_same(self):
         # A bit simpler, every point is the same.
@@ -40,9 +43,6 @@ class TestManifoldFunctional(unittest.TestCase):
         manifold.build_tree()
         # Even after explicit deepen calls.
         self.assertEqual(1, len(manifold.layers))
-        self.assertEqual(1, len(manifold.find_clusters(np.asarray([1, 1, 1]), 0.0, -1)))
-        # And, we should get all 1000 points back for any of the data.
-        self.assertEqual(1000, len(manifold.find_points(data[0], 0.0)))
         return
 
     def test_two_points_with_dups(self):
@@ -50,5 +50,8 @@ class TestManifoldFunctional(unittest.TestCase):
         data = np.concatenate([np.ones((500, 2)) * -2, np.ones((500, 2)) * 2])
         manifold = Manifold(data, 'euclidean').build()
         # We expect building to stop with two clusters.
-        self.assertEqual(2, manifold.graphs[0].cardinality, f'Expected 2 clusters, got {manifold.graphs[0].cardinality}')
+        self.assertEqual(2, manifold.layers[1].cardinality, f'Expected 2 clusters in the layer-graph at depth 1. '
+                                                            f'Got {manifold.layers[1].cardinality} instead.')
+        self.assertEqual(2, manifold.graphs[0].cardinality, f'Expected 2 clusters in the optimal graph. '
+                                                            f'Got {manifold.graphs[0].cardinality} instead.')
         return

--- a/pyclam/tests/test_search.py
+++ b/pyclam/tests/test_search.py
@@ -1,0 +1,63 @@
+import random
+import unittest
+from typing import Dict, List, Tuple
+
+import numpy as np
+from scipy.spatial.distance import cdist
+
+from pyclam import datasets
+from pyclam.chess import Search
+
+np.random.seed(42), random.seed(42)
+
+
+class TestCHESS(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.data, _ = datasets.bullseye(n=1000, num_rings=3)
+        cls.query, cls.metric = cls.data[0], 'euclidean'
+        cls.distances: Dict[int, float] = {
+            point: distance
+            for point, distance in zip(
+                range(cls.data.shape[0]),
+                cdist(np.asarray([cls.query]), cls.data, cls.metric)[0]
+            )
+        }
+        return
+
+    def test_init(self):
+        search = Search(self.data, 'euclidean')
+        self.assertEqual(0, search.depth, f'tree depth should be 0')
+
+        search = search.build(max_depth=5)
+        self.assertGreaterEqual(5, search.depth, f'tree depth should be 5')
+
+        search = search.build(max_depth=8)
+        self.assertGreaterEqual(8, search.depth, f'tree depth should be 8')
+        return
+
+    def test_rnn(self):
+        search = Search(self.data, self.metric).build(max_depth=10)
+
+        self.assertEqual(1, len(search.rnn(self.query, 0)))
+        self.assertLessEqual(1, len(search.rnn(self.query, 1)))
+
+        for radius in [0.25, 0.5, 1.0, 2.0, 5.0]:
+            naive_results: List[int] = [point for point, distance in self.distances.items() if distance <= radius]
+            rnn_results: List[int] = list(search.rnn(self.query, radius).keys())
+            self.assertEqual(len(naive_results), len(rnn_results), f'expected the same number of results from naive and rnn searches.')
+            self.assertSetEqual(set(naive_results), set(rnn_results), f'expected the same set of results from naive and rnn searches.')
+        return
+
+    def test_knn(self):
+        search = Search(self.data, self.metric).build(max_depth=10)
+        points: List[Tuple[float, int]] = list(sorted([(distance, point) for point, distance in self.distances.items()]))
+
+        ks: List[int] = list(range(1, 10))
+        ks.extend(range(10, self.data.shape[0], 1000))
+        for k in ks:
+            naive_results: List[int] = [point for _, point in points[:k]]
+            knn_results: List[int] = list(search.knn(self.query, k).keys())
+            self.assertEqual(len(naive_results), len(knn_results), f'expected the same number of results from naive and knn searches.')
+            self.assertSetEqual(set(naive_results), set(knn_results), f'expected the same set of results from naive and knn searches.')
+        return

--- a/pyclam/tests/utils.py
+++ b/pyclam/tests/utils.py
@@ -1,5 +1,7 @@
 """ Utilities for Testing.
 """
+from typing import Dict
+
 import numpy as np
 from scipy.spatial.distance import cdist
 
@@ -7,17 +9,17 @@ from pyclam.manifold import BATCH_SIZE, Cluster
 from pyclam.types import Data, Radius
 
 
-def linear_search(point: Data, radius: Radius, data: Data, metric: str):
+def linear_search(point: Data, radius: Radius, data: Data, metric: str) -> Dict[int, float]:
     point = np.expand_dims(point, 0)
-    results = []
+    results: Dict[int, float] = dict()
     for i in range(0, len(data), BATCH_SIZE):
         batch = data[i: i + BATCH_SIZE]
         distances = cdist(point, batch, metric)[0]
-        results.extend([p for p, d in zip(batch, distances) if d <= radius])
+        results.update({p: d for p, d in zip(batch, distances) if d <= radius})
     return results
 
 
-def trace_lineage(cluster: Cluster, other: Cluster):  # TODO: Cover
+def trace_lineage(cluster: Cluster, other: Cluster):
     assert cluster.depth == other.depth
     assert cluster.overlaps(other.medoid, other.radius)
     lineage = [other.name[:i] for i in range(other.depth) if cluster.name[:i] != other.name[:i]]

--- a/pyclam/types.py
+++ b/pyclam/types.py
@@ -1,9 +1,10 @@
 from collections import namedtuple
-from typing import Union, List, Callable
+from typing import Union, List, Callable, Tuple
 
 import numpy as np
 
-Data = Union[np.memmap, np.ndarray]
+Data = Union[np.memmap, np.ndarray]  # the entire dataset
+Datum = Union[int, np.ndarray]  # a point, or the index of a point
 Radius = Union[float, int, np.float64]
 Vector = List[int]
 DistanceFunc = Callable[[Data, Data], Radius]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyclam"
-version = "0.2.9"
+version = "0.2.10"
 description = "Clustered Learning of Approximate Manifolds"
 authors = ["Tom Howard <info@tomhoward.codes>", "Najib Ishaq <najib_ishaq@zoho.com>", "Noah Daniels <noah_daniels@uri.edu>"]
 license = "MIT"


### PR DESCRIPTION
Created a CHESS module and moves all search functionality out of CLAM.

I think we should stick with this class, rather than using mixins or inheriting from Manifold, because of the upcoming Rust implementation. We will first implement CLAM in Rust, and start to use rust-clam in the chaoda and chess modules as they are in python. Later, when we implement the chess and chaoda modules in Rust, the current design will be much easier to port over in manageable chunks.