### PR TITLE
Cluster ratios are now in Manifold

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clam"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Tom Howard <info@tomhoward.codes>", "Najib Ishaq <nishaq@my.uri.edu>", "Noah Daniels <noah_daniels@uri.edu>"]
 edition = "2018"
 

--- a/pyclam/criterion.py
+++ b/pyclam/criterion.py
@@ -229,16 +229,10 @@ class LinearRegressionConstants(SelectionCriterion):
         return self.mode(root.manifold, predicted_auc)
 
     def _predict_auc(self, manifold: Manifold) -> Dict[Cluster, float]:
-        predicted_auc: Dict[Cluster, float] = {
-            cluster: float(np.dot(self.constants, np.concatenate([
-                np.asarray(cluster.ratios, dtype=float),
-                np.asarray(cluster.ema_ratios, dtype=float)
-            ])))
-            for layer in manifold.layers
-            for cluster in layer.clusters
-            if cluster.depth == layer.depth
+        return {
+            cluster: float(np.dot(self.constants, manifold.cluster_ratios(cluster)))
+            for cluster in manifold.ordered_clusters
         }
-        return predicted_auc
 
 
 class RegressionTreePaths(SelectionCriterion):
@@ -258,9 +252,7 @@ class RegressionTreePaths(SelectionCriterion):
     def __call__(self, root: Cluster) -> Set[Cluster]:
         predicted_auc: Dict[Cluster, float] = {
             cluster: self.predict_auc(cluster)
-            for layer in root.manifold.layers
-            for cluster in layer.clusters
-            if cluster.depth == layer.depth
+            for cluster in root.manifold.ordered_clusters
         }
         return self.mode(root.manifold, predicted_auc)
 

--- a/pyclam/search.py
+++ b/pyclam/search.py
@@ -3,7 +3,7 @@ from typing import Dict, Optional, List, Set, Tuple
 import numpy as np
 
 import pyclam.criterion as criterion
-from pyclam.manifold import Manifold, Cluster
+from pyclam.manifold import Manifold, Cluster, EPSILON
 from pyclam.types import Data, Metric, Datum
 
 ClusterResults = Dict[Cluster, float]
@@ -83,7 +83,7 @@ class Search:
                 lfd = 1 if half_count == 0 else np.log2(len(hits) / half_count)
 
             # increase radius as guided by lfd
-            factor = (k / len(hits)) ** (1 / lfd)
+            factor = (k / len(hits)) ** (1 / (lfd + EPSILON))
             assert factor > 1, f'expected factor to be greater than 1. Got {factor:.2e} instead.'
             radius *= factor
 

--- a/pyclam/utils.py
+++ b/pyclam/utils.py
@@ -7,6 +7,7 @@ from scipy.special import erf
 
 SUBSAMPLE_LIMIT = 100
 BATCH_SIZE = 10_000
+EPSILON = 1e-8
 
 
 def catch_normalization_mode(mode: str) -> None:
@@ -18,20 +19,25 @@ def catch_normalization_mode(mode: str) -> None:
         return
 
 
-def normalize(scores: np.array, mode: str) -> np.array:
-    """ Normalize a 1-d array of values into a [0, 1] range. """
+def normalize(values: np.array, mode: str) -> np.array:
+    """ Normalizes values into a [0, 1] range.
+
+    :param values: 1-d array of values to normalize.
+    :param mode: Normalization mode to use. Must be one of 'linear', 'gaussian', or 'sigmoid'.
+    :return: 1-d array of normalized values.
+    """
     if mode == 'linear':
-        min_v, max_v, = float(np.min(scores)), float(np.max(scores))
+        min_v, max_v, = float(np.min(values)), float(np.max(values))
         if min_v == max_v:
             max_v += 1.
-        scores = (scores - min_v) / (max_v - min_v)
+        values = (values - min_v) / (max_v - min_v)
     else:
-        mu: float = float(np.mean(scores))
-        sigma: float = max(float(np.std(scores)), 1e-3)
+        mu: float = float(np.mean(values))
+        sigma: float = max(float(np.std(values)), 1e-3)
 
         if mode == 'gaussian':
-            scores = erf((scores - mu) / (sigma * np.sqrt(2)))
+            values = erf((values - mu) / (sigma * np.sqrt(2)))
         else:
-            scores = 1 / (1 + np.exp(-(scores - mu) / sigma))
+            values = 1 / (1 + np.exp(-(values - mu) / sigma))
 
-    return scores.ravel().clip(0, 1)
+    return values.ravel().clip(0, 1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyclam"
-version = "0.3.0"
+version = "0.3.1"
 description = "Clustered Learning of Approximate Manifolds"
 authors = ["Tom Howard <info@tomhoward.codes>", "Najib Ishaq <najib_ishaq@zoho.com>", "Noah Daniels <noah_daniels@uri.edu>"]
 license = "MIT"


### PR DESCRIPTION
because we can now properly normalize the ratios and make them dataset-independent.