### PR TITLE
Added tree-search-history method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clam"
-version = "0.3.5"
+version = "0.3.6"
 authors = ["Tom Howard <info@tomhoward.codes>", "Najib Ishaq <nishaq@my.uri.edu>", "Noah Daniels <noah_daniels@uri.edu>"]
 edition = "2018"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyclam"
-version = "0.3.5"
+version = "0.3.6"
 description = "Clustered Learning of Approximate Manifolds"
 authors = ["Tom Howard <info@tomhoward.codes>", "Najib Ishaq <najib_ishaq@zoho.com>", "Noah Daniels <noah_daniels@uri.edu>"]
 license = "MIT"


### PR DESCRIPTION
This method, in addition to returning the hits for regular tree-search, also returns the history of all candidate clusters at each depth during the search.

This is going to be useful for supervised learning in CHAODA.