### PR TITLE
Implemented reordering logic into new dataset schema

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ authors = [
     "Noah Daniels <noah_daniels@uri.edu>",
     "Morgan Prior <morgan_prior@uri.edu>",
     "Isaac Chen <ijchen@uri.edu>",
+    "Oliver McLaughlin <olwmcjp@gmail.com>",
 ]
 edition = "2021"
 rust-version = "1.68"


### PR DESCRIPTION
*Assigned to me by Najib*

## Overview
This PR implements dataset reordering logic for `VecVec`. A new function in the `Dataset` trait called `reorder` takes a list of indices and applies that list of indices to the dataset like a permutation.

## Tests
`core::dataset::test_reordering` - Tests table reordering on a randomly generated three-dimensional dataset with increasing lengths. The maximum length could be decreased before merging to speed up test time. Currently running this test takes ~0.25 seconds on my laptop.

## Questions
- [ ] Should I keep the documentation? I'm not sure what the documentation style of this project is.
- [ ] Should indices be validated? I.e. we would reject index lists that contained duplicates, numbers out of range (n > cardinality), etc.
- [ ] Should this be implemented in the `Dataset` trait or just `VecVec`? I imagine we would like to do table reordering on all datasets, so I implemented it for `Dataset`, though I'm not sure.