### PR TITLE
Needleman wunsch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,3 +76,8 @@ harness = false
 [[bench]]
 name = "knn-search"
 harness = false
+
+[[bench]]
+name = "needleman-wunsch"
+harness = false
+

--- a/benches/needleman-wunsch.rs
+++ b/benches/needleman-wunsch.rs
@@ -1,0 +1,104 @@
+use criterion::*;
+
+use clam::distances::alignment_helpers;
+use clam::distances::strings;
+use clam::utils::helpers;
+
+fn needleman_wunsch_dim(c: &mut Criterion) {
+    let mut group = c.benchmark_group("needleman-wunsch-dim");
+    group.significance_level(0.025).sample_size(10);
+
+    let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
+    group.plot_config(plot_config);
+
+    group.sampling_mode(SamplingMode::Flat);
+
+    for n in [10, 25, 50, 100, 250, 500, 1000] {
+        let data = helpers::gen_data_u8(2, n, 65, 68, 42);
+        let x = &data[0];
+        let y = &data[1];
+        let id = BenchmarkId::new("nw", n);
+        group.bench_with_input(id, &n, |b, _| {
+            b.iter_with_large_drop(|| strings::needleman_wunsch_with_edits::<u8, u32>(x, y));
+        });
+    }
+
+    group.finish();
+}
+
+fn needleman_wunsch_alphabet_size(c: &mut Criterion) {
+    let mut group = c.benchmark_group("needleman-wunsch-alphabet-size");
+    group.significance_level(0.025).sample_size(10);
+
+    let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
+    group.plot_config(plot_config);
+
+    group.sampling_mode(SamplingMode::Flat);
+
+    for alphabet_size in [4, 8, 16, 32] {
+        let data = helpers::gen_data_u8(2, 50, 65, 65 + alphabet_size, 42);
+        let x = &data[0];
+        let y = &data[1];
+        let id = BenchmarkId::new("nw", alphabet_size);
+        group.bench_with_input(id, &alphabet_size, |b, _| {
+            b.iter_with_large_drop(|| strings::needleman_wunsch_with_edits::<u8, u32>(x, y));
+        });
+    }
+
+    group.finish();
+}
+
+fn traceback_iterative_dim(c: &mut Criterion) {
+    let mut group = c.benchmark_group("traceback-iterative-dim");
+    group.significance_level(0.025).sample_size(10);
+
+    let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
+    group.plot_config(plot_config);
+
+    group.sampling_mode(SamplingMode::Flat);
+
+    for n in [10, 25, 50, 100, 250, 500, 1000] {
+        let data = helpers::gen_data_u8(2, n, 65, 68, 42);
+        let x = &data[0];
+        let y = &data[1];
+        let table: Vec<Vec<(usize, alignment_helpers::Direction)>> = alignment_helpers::compute_nw_table(x, y);
+        let id = BenchmarkId::new("nw-traceback-iterative", n);
+        group.bench_with_input(id, &n, |b, _| {
+            b.iter_with_large_drop(|| alignment_helpers::traceback_iterative(&table, (x, y)));
+        });
+    }
+
+    group.finish();
+}
+
+fn traceback_recursive_dim(c: &mut Criterion) {
+    let mut group = c.benchmark_group("traceback-recursive-dim");
+    group.significance_level(0.025).sample_size(10);
+
+    let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
+    group.plot_config(plot_config);
+
+    group.sampling_mode(SamplingMode::Flat);
+
+    for n in [10, 25, 50, 100, 250, 500, 1000] {
+        let data = helpers::gen_data_u8(2, n, 65, 68, 42);
+        let x = &data[0];
+        let y = &data[1];
+        let table: Vec<Vec<(usize, alignment_helpers::Direction)>> = alignment_helpers::compute_nw_table(x, y);
+        let id = BenchmarkId::new("nw-traceback-recursive", n);
+        group.bench_with_input(id, &n, |b, _| {
+            b.iter_with_large_drop(|| alignment_helpers::traceback_recursive(&table, (x, y)));
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    needleman_wunsch_dim,
+    needleman_wunsch_alphabet_size,
+    traceback_recursive_dim,
+    traceback_iterative_dim
+);
+criterion_main!(benches);

--- a/benches/needleman-wunsch.rs
+++ b/benches/needleman-wunsch.rs
@@ -1,11 +1,10 @@
 use criterion::*;
 
-use clam::distances::alignment_helpers;
 use clam::distances::strings;
 use clam::utils::helpers;
 
-fn needleman_wunsch_dim(c: &mut Criterion) {
-    let mut group = c.benchmark_group("needleman-wunsch-dim");
+fn needleman_wunsch_recursive_dim(c: &mut Criterion) {
+    let mut group = c.benchmark_group("needleman-wunsch-recursive-dim");
     group.significance_level(0.025).sample_size(10);
 
     let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
@@ -19,15 +18,37 @@ fn needleman_wunsch_dim(c: &mut Criterion) {
         let y = &data[1];
         let id = BenchmarkId::new("nw", n);
         group.bench_with_input(id, &n, |b, _| {
-            b.iter_with_large_drop(|| strings::needleman_wunsch_with_edits::<u8, u32>(x, y));
+            b.iter_with_large_drop(|| strings::needleman_wunsch_with_edits_recursive::<u8, u32>(x, y));
         });
     }
 
     group.finish();
 }
 
-fn needleman_wunsch_alphabet_size(c: &mut Criterion) {
-    let mut group = c.benchmark_group("needleman-wunsch-alphabet-size");
+fn needleman_wunsch_iterative_dim(c: &mut Criterion) {
+    let mut group = c.benchmark_group("needleman-wunsch-iterative-dim");
+    group.significance_level(0.025).sample_size(10);
+
+    let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
+    group.plot_config(plot_config);
+
+    group.sampling_mode(SamplingMode::Flat);
+
+    for n in [10, 25, 50, 100, 250, 500, 1000] {
+        let data = helpers::gen_data_u8(2, n, 65, 68, 42);
+        let x = &data[0];
+        let y = &data[1];
+        let id = BenchmarkId::new("nw", n);
+        group.bench_with_input(id, &n, |b, _| {
+            b.iter_with_large_drop(|| strings::needleman_wunsch_with_edits_iterative::<u8, u32>(x, y));
+        });
+    }
+
+    group.finish();
+}
+
+fn needleman_wunsch_recursive_alphabet_size(c: &mut Criterion) {
+    let mut group = c.benchmark_group("needleman-wunsch-recursive-alphabet-size");
     group.significance_level(0.025).sample_size(10);
 
     let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
@@ -41,15 +62,15 @@ fn needleman_wunsch_alphabet_size(c: &mut Criterion) {
         let y = &data[1];
         let id = BenchmarkId::new("nw", alphabet_size);
         group.bench_with_input(id, &alphabet_size, |b, _| {
-            b.iter_with_large_drop(|| strings::needleman_wunsch_with_edits::<u8, u32>(x, y));
+            b.iter_with_large_drop(|| strings::needleman_wunsch_with_edits_recursive::<u8, u32>(x, y));
         });
     }
 
     group.finish();
 }
 
-fn traceback_iterative_dim(c: &mut Criterion) {
-    let mut group = c.benchmark_group("traceback-iterative-dim");
+fn needleman_wunsch_iterative_alphabet_size(c: &mut Criterion) {
+    let mut group = c.benchmark_group("needleman-wunsch-iterative-alphabet-size");
     group.significance_level(0.025).sample_size(10);
 
     let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
@@ -57,37 +78,13 @@ fn traceback_iterative_dim(c: &mut Criterion) {
 
     group.sampling_mode(SamplingMode::Flat);
 
-    for n in [10, 25, 50, 100, 250, 500, 1000] {
-        let data = helpers::gen_data_u8(2, n, 65, 68, 42);
+    for alphabet_size in [4, 8, 16, 32] {
+        let data = helpers::gen_data_u8(2, 50, 65, 65 + alphabet_size, 42);
         let x = &data[0];
         let y = &data[1];
-        let table: Vec<Vec<(usize, alignment_helpers::Direction)>> = alignment_helpers::compute_nw_table(x, y);
-        let id = BenchmarkId::new("nw-traceback-iterative", n);
-        group.bench_with_input(id, &n, |b, _| {
-            b.iter_with_large_drop(|| alignment_helpers::traceback_iterative(&table, (x, y)));
-        });
-    }
-
-    group.finish();
-}
-
-fn traceback_recursive_dim(c: &mut Criterion) {
-    let mut group = c.benchmark_group("traceback-recursive-dim");
-    group.significance_level(0.025).sample_size(10);
-
-    let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
-    group.plot_config(plot_config);
-
-    group.sampling_mode(SamplingMode::Flat);
-
-    for n in [10, 25, 50, 100, 250, 500, 1000] {
-        let data = helpers::gen_data_u8(2, n, 65, 68, 42);
-        let x = &data[0];
-        let y = &data[1];
-        let table: Vec<Vec<(usize, alignment_helpers::Direction)>> = alignment_helpers::compute_nw_table(x, y);
-        let id = BenchmarkId::new("nw-traceback-recursive", n);
-        group.bench_with_input(id, &n, |b, _| {
-            b.iter_with_large_drop(|| alignment_helpers::traceback_recursive(&table, (x, y)));
+        let id = BenchmarkId::new("nw", alphabet_size);
+        group.bench_with_input(id, &alphabet_size, |b, _| {
+            b.iter_with_large_drop(|| strings::needleman_wunsch_with_edits_recursive::<u8, u32>(x, y));
         });
     }
 
@@ -96,9 +93,9 @@ fn traceback_recursive_dim(c: &mut Criterion) {
 
 criterion_group!(
     benches,
-    needleman_wunsch_dim,
-    needleman_wunsch_alphabet_size,
-    traceback_recursive_dim,
-    traceback_iterative_dim
+    needleman_wunsch_recursive_dim,
+    needleman_wunsch_iterative_dim,
+    needleman_wunsch_recursive_alphabet_size,
+    needleman_wunsch_iterative_alphabet_size
 );
 criterion_main!(benches);

--- a/src/core/number/num_bool.rs
+++ b/src/core/number/num_bool.rs
@@ -1,12 +1,6 @@
 use super::Number;
 
-#[derive(
-    Debug,
-    Clone,
-    Copy,
-    PartialEq,
-    PartialOrd,
-)]
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
 pub struct NumBool<T: Number>(T);
 
 impl<T: Number> NumBool<T> {

--- a/src/distances/alignment_helpers.rs
+++ b/src/distances/alignment_helpers.rs
@@ -1,0 +1,559 @@
+use crate::number::Number;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Direction {
+    Diagonal,
+    Up,
+    Left,
+    None,
+}
+
+// New function to compute the distance and direction table using scoring scheme 0; 1; 1
+pub fn compute_nw_table<T: Number>(x: &[T], y: &[T]) -> Vec<Vec<(usize, Direction)>> {
+    let len_x = x.len();
+    let len_y = y.len();
+
+    // Initializing table; subvecs represent rows
+    let mut table = vec![vec![(0, Direction::None); len_x + 1]; len_y + 1];
+
+    let gap_penalty = 1;
+
+    // Initialize top row and left column distance values
+    for row in 0..(len_y + 1) {
+        table[row][0] = (gap_penalty * row, Direction::None);
+    }
+
+    for column in 0..(len_x + 1) {
+        table[0][column] = (gap_penalty * column, Direction::None);
+    }
+
+    // Set values for the body of the table
+    for row in 1..(len_y + 1) {
+        for col in 1..(len_x + 1) {
+            // Check if sequences match at position col-1 in x and row-1 in y
+            // Reason for subtraction is that NW considers an artificial gap at the start
+            // of each sequence, so the dp tables' indices are 1 higher than that of
+            // the actual sequences
+            let mismatch_penalty = if x[col - 1] == y[row - 1] { 0 } else { 1 };
+            let new_cell = [
+                table[row - 1][col - 1].0 + mismatch_penalty,
+                table[row - 1][col].0 + gap_penalty,
+                table[row][col - 1].0 + gap_penalty,
+            ]
+            .into_iter()
+            .zip([Direction::Diagonal, Direction::Up, Direction::Left].into_iter())
+            .min_by(|x, y| x.0.cmp(&y.0))
+            .unwrap();
+
+            table[row][col] = new_cell;
+        }
+    }
+
+    table
+}
+
+pub enum Edit<T: Number> {
+    Deletion(usize),
+    Insertion(usize, T),
+    Substitution(usize, T),
+}
+
+// Given an alignement of two sequences, returns the set of edits needed to turn sequence
+// x into sequence y
+pub fn alignment_to_edits<T: Number>(aligned_x: &Vec<T>, aligned_y: &Vec<T>) -> Vec<Edit<T>> {
+    aligned_x
+        .iter()
+        .zip(aligned_y.iter())
+        .filter(|(x, y)| x != y)
+        .enumerate()
+        .map(|(index, (x, y))| {
+            if *x == T::from(b'-').unwrap() {
+                Edit::Insertion(index, *y)
+            } else if *y == T::from(b'-').unwrap() {
+                Edit::Deletion(index)
+            } else {
+                Edit::Substitution(index, *y)
+            }
+        })
+        .collect()
+}
+
+// Iterative version of traceback function so we can benchmark both this and recursive option
+pub fn traceback_iterative<T: Number>(
+    table: &Vec<Vec<(usize, Direction)>>,
+    unaligned_seqs: (&[T], &[T]),
+) -> (Vec<T>, Vec<T>) {
+    let mut row_index = table.len() - 1;
+    let mut column_index = table[0].len() - 1;
+
+    let (mut aligned_x, mut aligned_y) = (Vec::<T>::new(), Vec::<T>::new());
+    let (unaligned_x, unaligned_y) = unaligned_seqs;
+    let mut direction = table[row_index][column_index].1;
+
+    while direction != Direction::None {
+        match direction {
+            Direction::Diagonal => {
+                aligned_x.insert(0, unaligned_x[column_index - 1]);
+                aligned_y.insert(0, unaligned_y[row_index - 1]);
+                row_index -= 1;
+                column_index -= 1;
+            }
+            Direction::Left => {
+                aligned_x.insert(0, unaligned_x[column_index - 1]);
+                aligned_y.insert(0, T::from(b'-').unwrap());
+                column_index -= 1;
+            }
+            Direction::Up => {
+                aligned_x.insert(0, T::from(b'-').unwrap());
+                aligned_y.insert(0, unaligned_y[row_index - 1]);
+                row_index -= 1;
+            }
+            Direction::None => {}
+        }
+
+        direction = table[row_index][column_index].1;
+    }
+
+    (aligned_x, aligned_y)
+}
+
+// Public function for recurisve traceback to get alignment and edit distance (ignores ties for now)
+pub fn traceback_recursive<T: Number>(
+    table: &Vec<Vec<(usize, Direction)>>,
+    unaligned_seqs: (&[T], &[T]),
+) -> (Vec<T>, Vec<T>) {
+    let indices = (table.len() - 1, table[0].len() - 1);
+
+    let alignment = _traceback_recursive(table, indices, unaligned_seqs, (Vec::new(), Vec::new()));
+
+    alignment
+}
+
+// Private traceback recursive function. Returns a single alignment (disregards ties for best-scoring alignment)
+fn _traceback_recursive<T: Number>(
+    table: &Vec<Vec<(usize, Direction)>>,
+    indices: (usize, usize),
+    unaligned_seqs: (&[T], &[T]),
+    aligned_seqs: (Vec<T>, Vec<T>),
+) -> (Vec<T>, Vec<T>) {
+    let (unaligned_x, unaligned_y) = unaligned_seqs;
+    let (mut aligned_x, mut aligned_y) = aligned_seqs;
+
+    let (mut row_index, mut column_index) = indices;
+
+    let direction = table[row_index][column_index].1;
+
+    match direction {
+        Direction::Diagonal => {
+            aligned_x.insert(0, unaligned_x[column_index - 1]);
+            aligned_y.insert(0, unaligned_y[row_index - 1]);
+            row_index -= 1;
+            column_index -= 1;
+        }
+        Direction::Left => {
+            aligned_x.insert(0, unaligned_x[column_index - 1]);
+            aligned_y.insert(0, T::from(b'-').unwrap());
+            column_index -= 1;
+        }
+        Direction::Up => {
+            aligned_x.insert(0, T::from(b'-').unwrap());
+            aligned_y.insert(0, unaligned_y[row_index - 1]);
+            row_index -= 1;
+        }
+        Direction::None => return (aligned_x, aligned_y),
+    };
+
+    _traceback_recursive(
+        table,
+        (row_index, column_index),
+        (unaligned_x, unaligned_y),
+        (aligned_x, aligned_y),
+    )
+}
+
+
+
+#[cfg(test)]
+mod tests {
+    use crate::distances::alignment_helpers::compute_nw_table;
+    use crate::distances::alignment_helpers::traceback_iterative;
+    use crate::distances::alignment_helpers::traceback_recursive;
+    use crate::distances::alignment_helpers::Direction;
+
+    #[test]
+    fn test_compute_table() {
+        let x_u8 = "NAJIBPEPPERSEATS".as_bytes();
+        let y_u8 = "NAJIBEATSPEPPERS".as_bytes();
+        let table = compute_nw_table(x_u8, y_u8);
+        assert_eq!(
+            table,
+            [
+                [
+                    (0, Direction::None),
+                    (1, Direction::None),
+                    (2, Direction::None),
+                    (3, Direction::None),
+                    (4, Direction::None),
+                    (5, Direction::None),
+                    (6, Direction::None),
+                    (7, Direction::None),
+                    (8, Direction::None),
+                    (9, Direction::None),
+                    (10, Direction::None),
+                    (11, Direction::None),
+                    (12, Direction::None),
+                    (13, Direction::None),
+                    (14, Direction::None),
+                    (15, Direction::None),
+                    (16, Direction::None)
+                ],
+                [
+                    (1, Direction::None),
+                    (0, Direction::Diagonal),
+                    (1, Direction::Left),
+                    (2, Direction::Left),
+                    (3, Direction::Left),
+                    (4, Direction::Left),
+                    (5, Direction::Left),
+                    (6, Direction::Left),
+                    (7, Direction::Left),
+                    (8, Direction::Left),
+                    (9, Direction::Left),
+                    (10, Direction::Left),
+                    (11, Direction::Left),
+                    (12, Direction::Left),
+                    (13, Direction::Left),
+                    (14, Direction::Left),
+                    (15, Direction::Left)
+                ],
+                [
+                    (2, Direction::None),
+                    (1, Direction::Up),
+                    (0, Direction::Diagonal),
+                    (1, Direction::Left),
+                    (2, Direction::Left),
+                    (3, Direction::Left),
+                    (4, Direction::Left),
+                    (5, Direction::Left),
+                    (6, Direction::Left),
+                    (7, Direction::Left),
+                    (8, Direction::Left),
+                    (9, Direction::Left),
+                    (10, Direction::Left),
+                    (11, Direction::Left),
+                    (12, Direction::Diagonal),
+                    (13, Direction::Left),
+                    (14, Direction::Left)
+                ],
+                [
+                    (3, Direction::None),
+                    (2, Direction::Up),
+                    (1, Direction::Up),
+                    (0, Direction::Diagonal),
+                    (1, Direction::Left),
+                    (2, Direction::Left),
+                    (3, Direction::Left),
+                    (4, Direction::Left),
+                    (5, Direction::Left),
+                    (6, Direction::Left),
+                    (7, Direction::Left),
+                    (8, Direction::Left),
+                    (9, Direction::Left),
+                    (10, Direction::Left),
+                    (11, Direction::Left),
+                    (12, Direction::Left),
+                    (13, Direction::Left)
+                ],
+                [
+                    (4, Direction::None),
+                    (3, Direction::Up),
+                    (2, Direction::Up),
+                    (1, Direction::Up),
+                    (0, Direction::Diagonal),
+                    (1, Direction::Left),
+                    (2, Direction::Left),
+                    (3, Direction::Left),
+                    (4, Direction::Left),
+                    (5, Direction::Left),
+                    (6, Direction::Left),
+                    (7, Direction::Left),
+                    (8, Direction::Left),
+                    (9, Direction::Left),
+                    (10, Direction::Left),
+                    (11, Direction::Left),
+                    (12, Direction::Left)
+                ],
+                [
+                    (5, Direction::None),
+                    (4, Direction::Up),
+                    (3, Direction::Up),
+                    (2, Direction::Up),
+                    (1, Direction::Up),
+                    (0, Direction::Diagonal),
+                    (1, Direction::Left),
+                    (2, Direction::Left),
+                    (3, Direction::Left),
+                    (4, Direction::Left),
+                    (5, Direction::Left),
+                    (6, Direction::Left),
+                    (7, Direction::Left),
+                    (8, Direction::Left),
+                    (9, Direction::Left),
+                    (10, Direction::Left),
+                    (11, Direction::Left)
+                ],
+                [
+                    (6, Direction::None),
+                    (5, Direction::Up),
+                    (4, Direction::Up),
+                    (3, Direction::Up),
+                    (2, Direction::Up),
+                    (1, Direction::Up),
+                    (1, Direction::Diagonal),
+                    (1, Direction::Diagonal),
+                    (2, Direction::Left),
+                    (3, Direction::Left),
+                    (4, Direction::Diagonal),
+                    (5, Direction::Left),
+                    (6, Direction::Left),
+                    (7, Direction::Diagonal),
+                    (8, Direction::Left),
+                    (9, Direction::Left),
+                    (10, Direction::Left)
+                ],
+                [
+                    (7, Direction::None),
+                    (6, Direction::Up),
+                    (5, Direction::Diagonal),
+                    (4, Direction::Up),
+                    (3, Direction::Up),
+                    (2, Direction::Up),
+                    (2, Direction::Diagonal),
+                    (2, Direction::Diagonal),
+                    (2, Direction::Diagonal),
+                    (3, Direction::Diagonal),
+                    (4, Direction::Diagonal),
+                    (5, Direction::Diagonal),
+                    (6, Direction::Diagonal),
+                    (7, Direction::Diagonal),
+                    (7, Direction::Diagonal),
+                    (8, Direction::Left),
+                    (9, Direction::Left)
+                ],
+                [
+                    (8, Direction::None),
+                    (7, Direction::Up),
+                    (6, Direction::Up),
+                    (5, Direction::Up),
+                    (4, Direction::Up),
+                    (3, Direction::Up),
+                    (3, Direction::Diagonal),
+                    (3, Direction::Diagonal),
+                    (3, Direction::Diagonal),
+                    (3, Direction::Diagonal),
+                    (4, Direction::Diagonal),
+                    (5, Direction::Diagonal),
+                    (6, Direction::Diagonal),
+                    (7, Direction::Diagonal),
+                    (8, Direction::Diagonal),
+                    (7, Direction::Diagonal),
+                    (8, Direction::Left)
+                ],
+                [
+                    (9, Direction::None),
+                    (8, Direction::Up),
+                    (7, Direction::Up),
+                    (6, Direction::Up),
+                    (5, Direction::Up),
+                    (4, Direction::Up),
+                    (4, Direction::Diagonal),
+                    (4, Direction::Diagonal),
+                    (4, Direction::Diagonal),
+                    (4, Direction::Diagonal),
+                    (4, Direction::Diagonal),
+                    (5, Direction::Diagonal),
+                    (5, Direction::Diagonal),
+                    (6, Direction::Left),
+                    (7, Direction::Left),
+                    (8, Direction::Up),
+                    (7, Direction::Diagonal)
+                ],
+                [
+                    (10, Direction::None),
+                    (9, Direction::Up),
+                    (8, Direction::Up),
+                    (7, Direction::Up),
+                    (6, Direction::Up),
+                    (5, Direction::Up),
+                    (4, Direction::Diagonal),
+                    (5, Direction::Diagonal),
+                    (4, Direction::Diagonal),
+                    (4, Direction::Diagonal),
+                    (5, Direction::Diagonal),
+                    (5, Direction::Diagonal),
+                    (6, Direction::Diagonal),
+                    (6, Direction::Diagonal),
+                    (7, Direction::Diagonal),
+                    (8, Direction::Diagonal),
+                    (8, Direction::Up)
+                ],
+                [
+                    (11, Direction::None),
+                    (10, Direction::Up),
+                    (9, Direction::Up),
+                    (8, Direction::Up),
+                    (7, Direction::Up),
+                    (6, Direction::Up),
+                    (5, Direction::Up),
+                    (4, Direction::Diagonal),
+                    (5, Direction::Up),
+                    (5, Direction::Diagonal),
+                    (4, Direction::Diagonal),
+                    (5, Direction::Left),
+                    (6, Direction::Diagonal),
+                    (6, Direction::Diagonal),
+                    (7, Direction::Diagonal),
+                    (8, Direction::Diagonal),
+                    (9, Direction::Diagonal)
+                ],
+                [
+                    (12, Direction::None),
+                    (11, Direction::Up),
+                    (10, Direction::Up),
+                    (9, Direction::Up),
+                    (8, Direction::Up),
+                    (7, Direction::Up),
+                    (6, Direction::Diagonal),
+                    (5, Direction::Up),
+                    (4, Direction::Diagonal),
+                    (5, Direction::Diagonal),
+                    (5, Direction::Up),
+                    (5, Direction::Diagonal),
+                    (6, Direction::Diagonal),
+                    (7, Direction::Diagonal),
+                    (7, Direction::Diagonal),
+                    (8, Direction::Diagonal),
+                    (9, Direction::Diagonal)
+                ],
+                [
+                    (13, Direction::None),
+                    (12, Direction::Up),
+                    (11, Direction::Up),
+                    (10, Direction::Up),
+                    (9, Direction::Up),
+                    (8, Direction::Up),
+                    (7, Direction::Diagonal),
+                    (6, Direction::Up),
+                    (5, Direction::Diagonal),
+                    (4, Direction::Diagonal),
+                    (5, Direction::Left),
+                    (6, Direction::Diagonal),
+                    (6, Direction::Diagonal),
+                    (7, Direction::Diagonal),
+                    (8, Direction::Diagonal),
+                    (8, Direction::Diagonal),
+                    (9, Direction::Diagonal)
+                ],
+                [
+                    (14, Direction::None),
+                    (13, Direction::Up),
+                    (12, Direction::Up),
+                    (11, Direction::Up),
+                    (10, Direction::Up),
+                    (9, Direction::Up),
+                    (8, Direction::Up),
+                    (7, Direction::Diagonal),
+                    (6, Direction::Up),
+                    (5, Direction::Up),
+                    (4, Direction::Diagonal),
+                    (5, Direction::Left),
+                    (6, Direction::Left),
+                    (6, Direction::Diagonal),
+                    (7, Direction::Left),
+                    (8, Direction::Left),
+                    (9, Direction::Diagonal)
+                ],
+                [
+                    (15, Direction::None),
+                    (14, Direction::Up),
+                    (13, Direction::Up),
+                    (12, Direction::Up),
+                    (11, Direction::Up),
+                    (10, Direction::Up),
+                    (9, Direction::Up),
+                    (8, Direction::Up),
+                    (7, Direction::Up),
+                    (6, Direction::Up),
+                    (5, Direction::Up),
+                    (4, Direction::Diagonal),
+                    (5, Direction::Left),
+                    (6, Direction::Left),
+                    (7, Direction::Diagonal),
+                    (8, Direction::Diagonal),
+                    (9, Direction::Diagonal)
+                ],
+                [
+                    (16, Direction::None),
+                    (15, Direction::Up),
+                    (14, Direction::Up),
+                    (13, Direction::Up),
+                    (12, Direction::Up),
+                    (11, Direction::Up),
+                    (10, Direction::Up),
+                    (9, Direction::Up),
+                    (8, Direction::Up),
+                    (7, Direction::Up),
+                    (6, Direction::Up),
+                    (5, Direction::Up),
+                    (4, Direction::Diagonal),
+                    (5, Direction::Left),
+                    (6, Direction::Left),
+                    (7, Direction::Left),
+                    (8, Direction::Diagonal)
+                ]
+            ]
+        );
+    }
+
+    #[test]
+    fn test_traceback_recursive() {
+        let x_u8 = "NAJIBPEPPERSEATS".as_bytes();
+        let y_u8 = "NAJIBEATSPEPPERS".as_bytes();
+        let table1: Vec<Vec<(usize, Direction)>> = compute_nw_table(x_u8, y_u8);
+        let nw_u8 = traceback_recursive(&table1, (x_u8, y_u8));
+        assert_eq!(
+            nw_u8,
+            (
+                [78, 65, 74, 73, 66, 45, 80, 69, 80, 80, 69, 82, 83, 69, 65, 84, 83].to_vec(),
+                [78, 65, 74, 73, 66, 69, 65, 84, 83, 80, 69, 80, 80, 69, 45, 82, 83].to_vec()
+            )
+        );
+
+        let x = "NOTGUILTY".as_bytes();
+        let y = "NOTGUILTY".as_bytes();
+        let table2: Vec<Vec<(usize, Direction)>> = compute_nw_table(x, y);
+        let nw = traceback_recursive(&table2, (x, y));
+        assert_eq!(
+            nw,
+            (
+                [78, 79, 84, 71, 85, 73, 76, 84, 89].to_vec(),
+                [78, 79, 84, 71, 85, 73, 76, 84, 89].to_vec()
+            )
+        );
+    }
+
+    #[test]
+    fn test_traceback_iterative() {
+        let x_u8 = "NAJIBPEPPERSEATS".as_bytes();
+        let y_u8 = "NAJIBEATSPEPPERS".as_bytes();
+        let table1: Vec<Vec<(usize, Direction)>> = compute_nw_table(x_u8, y_u8);
+        let nw_u8 = traceback_iterative(&table1, (x_u8, y_u8));
+        assert_eq!(
+            nw_u8,
+            (
+                [78, 65, 74, 73, 66, 45, 80, 69, 80, 80, 69, 82, 83, 69, 65, 84, 83].to_vec(),
+                [78, 65, 74, 73, 66, 69, 65, 84, 83, 80, 69, 80, 80, 69, 45, 82, 83].to_vec()
+            ),
+        );
+    }
+}

--- a/src/distances/mod.rs
+++ b/src/distances/mod.rs
@@ -1,4 +1,4 @@
-pub mod alignment_helpers;
+pub(crate) mod alignment_helpers;
 pub mod f32;
 pub mod lp_norms;
 pub mod misc;

--- a/src/distances/mod.rs
+++ b/src/distances/mod.rs
@@ -1,3 +1,4 @@
+pub mod alignment_helpers;
 pub mod f32;
 pub mod lp_norms;
 pub mod misc;

--- a/src/distances/strings.rs
+++ b/src/distances/strings.rs
@@ -1,4 +1,5 @@
 use crate::core::number::Number;
+use crate::distances::alignment_helpers;
 
 pub fn levenshtein<T: Number, U: Number>(x: &[T], y: &[T]) -> U {
     let (len_x, len_y) = (x.len(), y.len());
@@ -43,9 +44,40 @@ pub fn levenshtein<T: Number, U: Number>(x: &[T], y: &[T]) -> U {
     }
 }
 
+// Wrapper function for calculating distance based on NW-aligned sequences (returns edit distance only)
+pub fn needleman_wunsch<T: Number, U: Number>(x: &[T], y: &[T]) -> U {
+    let table = alignment_helpers::compute_nw_table(x, y);
+    let edit_distance: usize = table[table.len() - 1][table[0].len() - 1].0;
+
+    U::from(edit_distance).unwrap()
+}
+
+/*
+Function for calculating calculating distance based on NW-aligned sequences (returns edit
+distance AND alignment associated with shortest edit distance)
+
+For now, in cases where there exist ties for the shortest edit distance, we only return
+one alignment
+*/
+pub fn needleman_wunsch_with_edits<T: Number, U: Number>(
+    x: &[T],
+    y: &[T],
+) -> ((Vec<alignment_helpers::Edit<T>>, Vec<alignment_helpers::Edit<T>>), U) {
+    let table = alignment_helpers::compute_nw_table(x, y);
+    let (aligned_x, aligned_y) = alignment_helpers::traceback_recursive(&table, (x, y));
+
+    let edit_x_into_y = alignment_helpers::alignment_to_edits(&aligned_x, &aligned_y);
+    let edit_y_into_x = alignment_helpers::alignment_to_edits(&aligned_y, &aligned_x);
+
+    let edit_distance: usize = table[table.len() - 1][table[0].len() - 1].0;
+
+    ((edit_x_into_y, edit_y_into_x), U::from(edit_distance).unwrap())
+}
+
 #[cfg(test)]
 mod tests {
     use super::levenshtein;
+    use super::needleman_wunsch;
 
     #[test]
     fn test_levenshtein() {
@@ -55,5 +87,23 @@ mod tests {
         let lev: i32 = levenshtein(&x, &y);
 
         assert_eq!(lev, 3)
+    }
+
+    #[test]
+    fn test_needleman_wunsch() {
+        let x_int = [0, 1, 2, 2, 1, 3, 4];
+        let y_int = [5, 1, 2, 2, 6, 3];
+        let nw_int: i32 = needleman_wunsch(&x_int, &y_int);
+        assert_eq!(nw_int, 3);
+
+        let x_u8 = "NAJIBEATSPEPPERS".as_bytes();
+        let y_u8 = "NAJIBPEPPERSEATS".as_bytes();
+        let nw_u8: u8 = needleman_wunsch(x_u8, y_u8);
+        assert_eq!(nw_u8, 8);
+
+        let x = "NOTGUILTY".as_bytes();
+        let y = "NOTGUILTY".as_bytes();
+        let nw: u8 = needleman_wunsch(x, y);
+        assert_eq!(nw, 0);
     }
 }

--- a/src/distances/strings.rs
+++ b/src/distances/strings.rs
@@ -1,5 +1,5 @@
-use crate::core::number::Number;
-use crate::distances::alignment_helpers;
+use super::alignment_helpers;
+use crate::number::Number;
 
 pub fn levenshtein<T: Number, U: Number>(x: &[T], y: &[T]) -> U {
     let (len_x, len_y) = (x.len(), y.len());
@@ -44,7 +44,17 @@ pub fn levenshtein<T: Number, U: Number>(x: &[T], y: &[T]) -> U {
     }
 }
 
-// Wrapper function for calculating distance based on NW-aligned sequences (returns edit distance only)
+/// Calculate the edit distance between two strings using Needleman-Wunsch table.
+/// This function is only accurate with a scoring scheme for which all penalties
+/// are non-negative.
+///
+/// * [Demo](https://bioboot.github.io/bimm143_W20/class-material/nw/)
+/// * [Wikipedia](https://en.wikipedia.org/wiki/Needleman%E2%80%93Wunsch_algorithm)
+///
+/// # Arguments:
+///
+/// * `x`: unaligned sequence represented as a slice of type T
+/// * `y`: unaligned sequence represented as a slice of type T
 pub fn needleman_wunsch<T: Number, U: Number>(x: &[T], y: &[T]) -> U {
     let table = alignment_helpers::compute_nw_table(x, y);
     let edit_distance: usize = table[table.len() - 1][table[0].len() - 1].0;
@@ -52,17 +62,23 @@ pub fn needleman_wunsch<T: Number, U: Number>(x: &[T], y: &[T]) -> U {
     U::from(edit_distance).unwrap()
 }
 
-/*
-Function for calculating calculating distance based on NW-aligned sequences (returns edit
-distance AND alignment associated with shortest edit distance)
-
-For now, in cases where there exist ties for the shortest edit distance, we only return
-one alignment
-*/
-pub fn needleman_wunsch_with_edits<T: Number, U: Number>(
+/// Determine the set of edits needed to turn one unaligned sequence into another,
+/// as well as the edit distance between the two sequences.
+///
+/// Contrast to `needleman_wunsch_with_edits_iterative`, which uses an iterative, as
+/// opposed to recursive, traceback function
+///
+/// For now, in cases where there exist ties for the shortest edit distance, we only
+/// return one alignment.
+///
+/// # Arguments:
+///
+/// * `x`: unaligned sequence represented as a slice of type T
+/// * `y`: unaligned sequence represented as a slice of type T
+pub fn needleman_wunsch_with_edits_recursive<T: Number, U: Number>(
     x: &[T],
     y: &[T],
-) -> ((Vec<alignment_helpers::Edit<T>>, Vec<alignment_helpers::Edit<T>>), U) {
+) -> ([Vec<alignment_helpers::Edit<T>>; 2], U) {
     let table = alignment_helpers::compute_nw_table(x, y);
     let (aligned_x, aligned_y) = alignment_helpers::traceback_recursive(&table, (x, y));
 
@@ -71,7 +87,35 @@ pub fn needleman_wunsch_with_edits<T: Number, U: Number>(
 
     let edit_distance: usize = table[table.len() - 1][table[0].len() - 1].0;
 
-    ((edit_x_into_y, edit_y_into_x), U::from(edit_distance).unwrap())
+    ([edit_x_into_y, edit_y_into_x], U::from(edit_distance).unwrap())
+}
+
+/// Determine the set of edits needed to turn one unaligned sequence into another,
+/// as well as the edit distance between the two sequences.
+///
+/// Contrast to `needleman_wunsch_with_edits_recursive`, which uses a recursive, as
+/// opposed to iterative, traceback function
+///
+/// For now, in cases where there exist ties for the shortest edit distance, we only
+/// return one alignment.
+///
+/// # Arguments:
+///
+/// * `x`: unaligned sequence represented as a slice of type T
+/// * `y`: unaligned sequence represented as a slice of type T
+pub fn needleman_wunsch_with_edits_iterative<T: Number, U: Number>(
+    x: &[T],
+    y: &[T],
+) -> ([Vec<alignment_helpers::Edit<T>>; 2], U) {
+    let table = alignment_helpers::compute_nw_table(x, y);
+    let (aligned_x, aligned_y) = alignment_helpers::traceback_iterative(&table, (x, y));
+
+    let edit_x_into_y = alignment_helpers::alignment_to_edits(&aligned_x, &aligned_y);
+    let edit_y_into_x = alignment_helpers::alignment_to_edits(&aligned_y, &aligned_x);
+
+    let edit_distance: usize = table[table.len() - 1][table[0].len() - 1].0;
+
+    ([edit_x_into_y, edit_y_into_x], U::from(edit_distance).unwrap())
 }
 
 #[cfg(test)]

--- a/src/utils/helpers.rs
+++ b/src/utils/helpers.rs
@@ -14,6 +14,22 @@ use crate::core::number::Number;
 /// * `min_val`: of each axis in the hypercube
 /// * `max_val`: of each axis in the hypercube
 /// * `seed`: for the random number generator
+pub fn gen_data_u8(cardinality: usize, dimensionality: usize, min_val: u8, max_val: u8, seed: u64) -> Vec<Vec<u8>> {
+    let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(seed);
+    (0..cardinality)
+        .map(|_| (0..dimensionality).map(|_| rng.gen_range(min_val..=max_val)).collect())
+        .collect()
+}
+
+/// Generate a randomized tabular dataset for use in benchmarks and tests.
+///
+/// # Arguments:
+///
+/// * `cardinality`: number of points to generate.
+/// * `dimensionality`: dimensionality of points to generate.
+/// * `min_val`: of each axis in the hypercube
+/// * `max_val`: of each axis in the hypercube
+/// * `seed`: for the random number generator
 pub fn gen_data_f32(cardinality: usize, dimensionality: usize, min_val: f32, max_val: f32, seed: u64) -> Vec<Vec<f32>> {
     let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(seed);
     (0..cardinality)


### PR DESCRIPTION
Implemented Needleman-Wunsch for CLAM.  @ndaniels @nishaq503 @EmilyL1019 

Some comments: 
- Alignments are currently being returned as a tuple of Vecs of Edits (Deletion(index) or Insertion(index, character) or Substitution(index, character)).  The first element in the tuple represents the edits needed to turn the first sequence in to the second one and the latter represents the edits needed to go in the other direction. This can easily be reverted to have the function return two aligned sequences (as opposed to the set of edits) if desired. 
-  I have a function which gets edit distance from the distance table, but this is not necessary; under the scoring scheme (match: 0, gap: 1, mismatch: 1), the edit distance is the same as levenshtein, so you might as well just use levenshtein if all you care about is the distance. 
- For the traceback, we have two versions: recursive and iterative. There are benchmarks for both in benches/needleman-wunsch.rs. Iterative seems significantly faster right now. 
- I have benchmarks for both kinds of traceback function as well as two for the overall process: one which varies dimensionality and one which varies size of the alphabet. 
- I've only written tests for a few hand-calculated examples, which pass. We still need more robust, less arbitrary testing. 
- Right now, the function only returns one alignment (i.e., ignores ties). I am working on an alternative version (in Sequence Analysis repo) which won't ignore ties, but I figured this version was good enough for our current purposes