### PR TITLE
Optimized sieve V1.

### DIFF
--- a/abd-clam/benches/knn-search.rs
+++ b/abd-clam/benches/knn-search.rs
@@ -6,7 +6,7 @@ use abd_clam::{knn, Cakes, PartitionCriteria, VecDataset, COMMON_METRICS_F32};
 
 fn cakes(c: &mut Criterion) {
     let seed = 42;
-    let (cardinality, dimensionality) = (100_000, 10);
+    let (cardinality, dimensionality) = (1_000_000, 10);
     let (min_val, max_val) = (-1., 1.);
 
     let data = random_data::random_f32(cardinality, dimensionality, min_val, max_val, seed);
@@ -28,8 +28,7 @@ fn cakes(c: &mut Criterion) {
         let criteria = PartitionCriteria::new(true).with_min_cardinality(1);
         let cakes = Cakes::new(dataset, Some(seed), criteria);
 
-        let ks = [100, 10, 1];
-        for k in ks {
+        for k in (0..=8).map(|i| 2_usize.pow(i)) {
             let id = BenchmarkId::new("Linear", k);
             group.bench_with_input(id, &k, |b, _| {
                 b.iter_with_large_drop(|| cakes.batch_knn_search(&queries, k, knn::Algorithm::Linear));

--- a/abd-clam/src/cakes/knn/expanding_threshold.rs
+++ b/abd-clam/src/cakes/knn/expanding_threshold.rs
@@ -172,7 +172,7 @@ mod tests {
     use distances::vectors::euclidean;
     use symagen::random_data;
 
-    use crate::{cakes::knn::linear, Cakes, PartitionCriteria, VecDataset};
+    use crate::{cakes::knn::linear, knn::tests::sort_hits, Cakes, PartitionCriteria, VecDataset};
 
     #[test]
     fn expanding_thresholds() {
@@ -192,9 +192,8 @@ mod tests {
         let tree = model.tree();
 
         for k in [100, 10, 1] {
-            let linear_nn = linear::search(tree.data(), query, k, tree.indices());
-            let mut thresholds_nn = super::search(tree, query, k);
-            thresholds_nn.sort_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap());
+            let linear_nn = sort_hits(linear::search(tree.data(), query, k, tree.indices()));
+            let thresholds_nn = sort_hits(super::search(tree, query, k));
             assert_eq!(linear_nn, thresholds_nn);
         }
     }

--- a/abd-clam/src/cakes/knn/expanding_threshold.rs
+++ b/abd-clam/src/cakes/knn/expanding_threshold.rs
@@ -4,6 +4,8 @@ use distances::Number;
 
 use crate::{Cluster, Dataset, Tree};
 
+use super::{OrdNumber, RevNumber};
+
 /// K-Nearest Neighbor search with expanding threshold.
 ///
 /// /// # Arguments
@@ -111,58 +113,6 @@ fn trim_hits<U: Number>(k: usize, hits: &mut priority_queue::PriorityQueue<usize
     while hits.len() > k {
         hits.pop()
             .unwrap_or_else(|| unreachable!("`hits` is non-empty and has at least k elements."));
-    }
-}
-
-/// Field by which we rank elements in priority queue of hits.
-struct OrdNumber<T: Number>(T);
-
-impl<T: Number> PartialEq for OrdNumber<T> {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-
-impl<T: Number> Eq for OrdNumber<T> {}
-
-impl<T: Number> PartialOrd for OrdNumber<T> {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.0.partial_cmp(&other.0)
-    }
-}
-
-impl<T: Number> Ord for OrdNumber<T> {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.0
-            .partial_cmp(&other.0)
-            .unwrap_or_else(|| unreachable!("elements are always comparable"))
-    }
-}
-
-/// Field which functions as the reverse of `OrdNumber`, for ranking elements
-/// in the priority queue of candidates.
-struct RevNumber<T: Number>(T);
-
-impl<T: Number> PartialEq for RevNumber<T> {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-
-impl<T: Number> Eq for RevNumber<T> {}
-
-impl<T: Number> PartialOrd for RevNumber<T> {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        other.0.partial_cmp(&self.0)
-    }
-}
-
-impl<T: Number> Ord for RevNumber<T> {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        other
-            .0
-            .partial_cmp(&self.0)
-            .unwrap_or_else(|| unreachable!("elements are always comparable"))
     }
 }
 

--- a/abd-clam/src/cakes/knn/mod.rs
+++ b/abd-clam/src/cakes/knn/mod.rs
@@ -146,6 +146,7 @@ impl<I: Hash + Eq + Copy, U: Number> Hits<I, U> {
     }
 
     /// Number of hits in the queue.
+    #[allow(dead_code)]
     pub fn len(&self) -> usize {
         self.queue.len()
     }
@@ -258,10 +259,12 @@ impl<U: Number> Ord for RevNumber<U> {
 
 #[cfg(test)]
 mod tests {
+    use core::cmp::Ordering;
+
     use distances::Number;
 
     pub(crate) fn sort_hits<U: Number>(mut hits: Vec<(usize, U)>) -> Vec<(usize, U)> {
-        hits.sort_by(|(i, _), (j, _)| i.cmp(j));
+        hits.sort_by(|(_, i), (_, j)| i.partial_cmp(j).unwrap_or(Ordering::Greater));
         hits
     }
 }

--- a/abd-clam/src/cakes/knn/mod.rs
+++ b/abd-clam/src/cakes/knn/mod.rs
@@ -228,13 +228,31 @@ impl<U: Number> PartialOrd for OrdNumber<U> {
 
 impl<U: Number> Ord for OrdNumber<U> {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.partial_cmp(other).unwrap_or_else(|| {
-            unreachable!(
-                "All hits are instances, and
-        therefore each hit has a distance from the query. Since all hits' distances to the
-        query will be represented by the same type, we can always compare them."
-            )
-        })
+        self.partial_cmp(other).unwrap_or(Ordering::Greater)
+    }
+}
+
+/// Field by which we reverse-rank elements in priority queue of hits.
+#[derive(Debug)]
+pub struct RevNumber<U: Number>(U);
+
+impl<U: Number> PartialEq for RevNumber<U> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl<U: Number> Eq for RevNumber<U> {}
+
+impl<U: Number> PartialOrd for RevNumber<U> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        other.0.partial_cmp(&self.0)
+    }
+}
+
+impl<U: Number> Ord for RevNumber<U> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.partial_cmp(other).unwrap_or(Ordering::Greater)
     }
 }
 

--- a/abd-clam/src/cakes/knn/repeated_rnn.rs
+++ b/abd-clam/src/cakes/knn/repeated_rnn.rs
@@ -89,7 +89,7 @@ mod tests {
     use distances::vectors::euclidean;
     use symagen::random_data;
 
-    use crate::{cakes::knn::linear, Cakes, PartitionCriteria, VecDataset};
+    use crate::{cakes::knn::linear, knn::tests::sort_hits, Cakes, PartitionCriteria, VecDataset};
 
     #[test]
     fn repeated_rnn() {
@@ -109,8 +109,8 @@ mod tests {
         let tree = model.tree();
 
         for k in [100, 10, 1] {
-            let linear_nn = linear::search(tree.data(), query, k, tree.indices());
-            let repeated_nn = super::search(tree, query, k);
+            let linear_nn = sort_hits(linear::search(tree.data(), query, k, tree.indices()));
+            let repeated_nn = sort_hits(super::search(tree, query, k));
 
             assert_eq!(linear_nn, repeated_nn);
         }

--- a/abd-clam/src/cakes/knn/sieve_v1.rs
+++ b/abd-clam/src/cakes/knn/sieve_v1.rs
@@ -133,13 +133,6 @@ impl<'a, T: Send + Sync + Copy, U: Number> Grain<'a, T, U> {
         (self.multiplicity <= k) || self.is_leaf
     }
 
-    /// A Grain is "inside" the threshold if the furthest, worst-case possible point is at most as far as
-    /// threshold distance from the query.
-    #[allow(dead_code)]
-    pub fn is_inside(&self, threshold: U) -> bool {
-        self.d <= threshold
-    }
-
     /// A Grain is "outside" the threshold if the closest, best-case possible point is further than
     /// the threshold distance to the query.
     pub fn is_outside(&self, threshold: U) -> bool {

--- a/abd-clam/src/cakes/knn/sieve_v1.rs
+++ b/abd-clam/src/cakes/knn/sieve_v1.rs
@@ -1,15 +1,13 @@
 //! Search function and helper functions for Knn thresholds approach with no separate grains for
 //! cluster centers.
 
-use core::{cmp::Ordering, marker::PhantomData};
+use core::cmp::{min, Ordering};
 
 use distances::Number;
-use priority_queue::DoublePriorityQueue;
 
 use crate::{Cluster, Dataset, Tree};
 
-/// A type-alias for the priority queue of knn-hits.
-type Hits<U> = DoublePriorityQueue<usize, OrdNumber<U>>;
+use super::Hits;
 
 /// K-Nearest Neighbor search using a thresholds approach with no separate centers.
 ///
@@ -29,257 +27,154 @@ where
     U: Number,
     D: Dataset<T, U>,
 {
-    let mut sieve = SieveV1::new(tree, query, k);
-    sieve.initialize_grains();
-    while !sieve.is_refined() {
-        sieve.refine_step();
-    }
-    sieve.extract()
-}
+    let data = tree.data();
+    let c = tree.root();
+    let d = c.distance_to_instance(data, query);
 
-/// `SieveV1` is a data structure that is used to find the `k` nearest neighbors of a `query` point in a dataset.
-///
-/// The `KnnSieve` is initialized with a `tree`, a `query` point, and a `k` value. `tree` contains a
-/// hierarchical clustering of the dataset. The `query`  is the point for which we want to find the `k` nearest
-/// neighbors.
-///
-/// `grains` is a running list of `Grain`s (each grain consists of a cluster, a distance, and a multiplicity)
-/// which could still contain one of the `k` nearest neighbors. `hits` is a priority queue of points which could
-/// be one of the `k` nearest neighbors. `is refined` is a boolean which is true if hits contains exactly `k` points
-/// and there are no more `Grain`s which can be partitioned.
-///
-/// Contrast this to `SieveV2` which treats the center of a cluster separately from the rest of the points in the cluster.
-pub struct SieveV1<'a, T: Send + Sync + Copy, U: Number, D: Dataset<T, U>> {
-    /// The cluster tree to search.
-    tree: &'a Tree<T, U, D>,
-    /// The query point.
-    query: T,
-    /// The number of neighbors to find. The algorithm requires k > 0.
-    k: usize,
-    /// A vector of `Grains` which could still contain one of the k-nearest
-    /// neighbors. A `Grain` is a cluster, a distance, and a multiplicity.
-    grains: Vec<Grain<'a, T, U>>,
-    /// Whether hits contains the k-nearest neighbors.
-    is_refined: bool,
-    /// A priority queue of points which could be a nearest neighbor.
-    hits: Hits<U>,
-}
+    let mut grains = vec![Grain::new(c, d)];
+    let mut hits = Hits::new(k);
 
-impl<'a, T: Send + Sync + Copy, U: Number, D: Dataset<T, U>> SieveV1<'a, T, U, D> {
-    /// Creates a new instance of a `Sieve V1`.
-    pub fn new(tree: &'a Tree<T, U, D>, query: T, k: usize) -> Self {
-        Self {
-            tree,
-            query,
-            k,
-            grains: Vec::new(),
-            is_refined: false,
-            hits: Hits::default(),
-        }
-    }
+    loop {
+        // The threshold is the minimum distance, so far, which guarantees that
+        // the k nearest neighbors are within the threshold.
+        let i = Grain::partition(&mut grains, k, hits.len());
+        let threshold = grains[i].d;
 
-    /// One-time computation of `grains.`
-    pub fn initialize_grains(&mut self) {
-        let root = self.tree.root();
-        let distance = root.distance_to_instance(self.tree.data(), self.query);
-        let grain = Grain::new(root, distance + root.radius, root.cardinality);
-        self.grains = vec![grain];
-    }
+        // Remove hits which are outside the threshold.
+        hits.pop_until(threshold);
 
-    /// Returns whether search is complete, i.e., whether hits
-    /// contains the k-nearest neighbors.
-    const fn is_refined(&self) -> bool {
-        self.is_refined
-    }
-
-    /// One iteration of the refinement step.
-    pub fn refine_step(&mut self) {
-        // Determines the index of the grain such that if we only retain that grain
-        // and every closer grain, we are guaranteed to have at least k points.
-        // Threshold is the distance of the furthest point in the grain.
-        let i = Grain::partition_kth(&mut self.grains, self.k);
-        let ith_grain = &self.grains[i];
-        let threshold = ith_grain.d;
-
-        // Filters hits by being outside the threshold.
-        while !self.hits.is_empty()
-            && self
-                .hits
-                .peek_max()
-                .unwrap_or_else(|| unreachable!("`hits` is non-empty"))
-                .1
-                .number
-                > threshold
-        {
-            self.hits
-                .pop_max()
-                .unwrap_or_else(|| unreachable!("`hits` is non-empty"));
+        let (insiders, non_insiders) = grains.split_at_mut(i);
+        if non_insiders.is_empty() {
+            grains_to_hits(data, query, &mut hits, insiders);
+            break;
         }
 
-        // Partition into insiders and straddlers
-        #[allow(clippy::iter_with_drain)] // clippy is wrong in this case
-        let (mut insiders, straddlers): (Vec<_>, Vec<_>) = self
-            .grains
-            .drain(..)
-            .filter(|g| !Grain::is_outside(g, threshold))
-            .partition(|g| Grain::is_inside(g, threshold));
+        let (small_insiders, insiders) = insiders
+            .iter_mut()
+            .map(|&mut g| g)
+            .partition::<Vec<_>, _>(|g| g.is_small(k));
+        grains_to_hits(data, query, &mut hits, &small_insiders);
 
-        // Distinguish between those insiders we won't partition further and those we will
-        // Add instances from insiders we won't further partition to hits
-        let (small_insiders, big_insiders): (Vec<_>, Vec<_>) = insiders
+        let (leaves, non_leaves) = non_insiders
+            .iter_mut()
+            .filter(|g| !g.is_outside(threshold))
+            .map(|&mut g| g)
+            .partition::<Vec<_>, _>(|g| g.is_leaf);
+
+        // If there are no non-leaves then the search is complete.
+        if non_leaves.is_empty() {
+            grains_to_hits(data, query, &mut hits, &insiders);
+            grains_to_hits(data, query, &mut hits, &leaves);
+            break;
+        }
+
+        grains = non_leaves
             .into_iter()
-            .partition(|g| (g.multiplicity <= self.k) || g.c.is_leaf());
-        insiders = big_insiders;
-
-        for g in small_insiders {
-            let new_hits = g.c.indices(self.tree.data()).iter().map(|&i| {
-                (
-                    i,
-                    OrdNumber {
-                        number: self.tree.data().query_to_one(self.query, i),
-                    },
-                )
-            });
-            self.hits.extend(new_hits);
-        }
-
-        // If there are no straddlers or all of the straddlers are leaves, then the grains in insiders and straddlers
-        // are added to hits. If there are more than k hits, we repeatedly remove the furthest instance in hits until
-        // there are either k hits left or more than k hits with some ties
-        // If straddlers is not empty nor all leaves, partition non-leaves into children
-        if straddlers.is_empty() || straddlers.iter().all(|g| g.c.is_leaf()) {
-            insiders.into_iter().chain(straddlers.into_iter()).for_each(|g| {
-                let new_hits =
-                    g.c.indices(self.tree.data())
-                        .iter()
-                        .map(|&i| (i, self.tree.data().query_to_one(self.query, i)))
-                        .map(|(i, d)| (i, OrdNumber { number: d }));
-
-                self.hits.extend(new_hits);
-            });
-
-            if self.hits.len() > self.k {
-                self.trim_hits();
-            }
-
-            self.is_refined = true;
-        } else {
-            let (leaves, non_leaves): (Vec<_>, Vec<_>) = insiders
-                .into_iter()
-                .chain(straddlers.into_iter())
-                .partition(|g| g.c.is_leaf());
-
-            let children = non_leaves
-                .into_iter()
-                .flat_map(|g| {
-                    g.c.children()
-                        .unwrap_or_else(|| unreachable!("This is only called on non-leaves."))
-                })
-                .map(|c| (c, c.distance_to_instance(self.tree.data(), self.query)))
-                .map(|(c, d)| Grain::new(c, d + c.radius, c.cardinality));
-
-            self.grains = leaves.into_iter().chain(children).collect();
-        }
+            .chain(insiders.into_iter())
+            .flat_map(|g| {
+                g.c.children()
+                    .unwrap_or_else(|| unreachable!("This is only called on non-leaves."))
+            })
+            .map(|c| (c, c.distance_to_instance(data, query)))
+            .map(|(c, d)| Grain::new(c, d))
+            .chain(leaves.into_iter())
+            .collect();
     }
 
-    /// Trims hits to contain only the k-nearest neighbors.
-    pub fn trim_hits(&mut self) {
-        while self.hits.len() > self.k {
-            self.hits
-                .pop_max()
-                .unwrap_or_else(|| unreachable!("`hits` is non-empty and has at least k elements."));
-        }
-    }
+    hits.extract()
+}
 
-    /// Returns the indices and distances to the query of the k nearest neighbors of the query.
-    pub fn extract(&self) -> Vec<(usize, U)> {
-        self.hits.iter().map(|(&i, &OrdNumber { number: d })| (i, d)).collect()
-    }
+/// Adds the instances in grains to the hits.
+#[allow(clippy::needless_for_each)]
+fn grains_to_hits<T, U, D>(data: &D, query: T, hits: &mut Hits<usize, U>, grains: &[Grain<T, U>])
+where
+    T: Send + Sync + Copy,
+    U: Number,
+    D: Dataset<T, U>,
+{
+    grains.iter().for_each(|g| {
+        let indices = g.c.indices(data);
+        let distances = data.query_to_many(query, indices);
+        hits.push_batch(indices.iter().copied().zip(distances.into_iter()));
+    });
 }
 
 /// A Grain is a structure which stores a cluster, a distance, and a multiplicity.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 struct Grain<'a, T: Send + Sync + Copy, U: Number> {
-    /// Just something we have to do.
-    t_: std::marker::PhantomData<T>,
     /// The cluster.
     c: &'a Cluster<T, U>,
     /// The distance of the cluster's center to the query.
     d: U,
+    /// The diameter of the cluster.
+    diameter: U,
     /// The multiplicity of the cluster (in this version, multiplicity = cardinality)
     multiplicity: usize,
+    /// Whether the cluster is a leaf.
+    is_leaf: bool,
 }
 
 impl<'a, T: Send + Sync + Copy, U: Number> Grain<'a, T, U> {
     /// Creates a new instance of a Grain.
-    const fn new(c: &'a Cluster<T, U>, d: U, multiplicity: usize) -> Self {
-        let t = PhantomData;
+    fn new(c: &'a Cluster<T, U>, d: U) -> Self {
+        let r = c.radius;
         Self {
-            t_: t,
             c,
-            d,
-            multiplicity,
+            d: d + r,
+            diameter: r + r,
+            multiplicity: c.cardinality,
+            is_leaf: c.is_leaf(),
         }
+    }
+
+    /// A `Grain` is small if its multiplicity is less than or equal to k or if
+    /// its cluster is a leaf.
+    pub const fn is_small(&self, k: usize) -> bool {
+        (self.multiplicity <= k) || self.is_leaf
     }
 
     /// A Grain is "inside" the threshold if the furthest, worst-case possible point is at most as far as
     /// threshold distance from the query.
+    #[allow(dead_code)]
     pub fn is_inside(&self, threshold: U) -> bool {
-        self.d < threshold
+        self.d <= threshold
     }
 
     /// A Grain is "outside" the threshold if the closest, best-case possible point is further than
     /// the threshold distance to the query.
     pub fn is_outside(&self, threshold: U) -> bool {
-        let radius = self.c.radius;
-        let d_min = if self.d < radius + radius {
-            U::zero()
+        if self.d <= self.diameter {
+            // query is inside the cluster
+            false
         } else {
-            self.d - radius - radius
-        };
-        d_min > threshold
+            threshold < (self.d - self.diameter)
+        }
     }
 
     /// Wrapper function for `_partition_kth`.
-    pub fn partition_kth(grains: &mut [Self], k: usize) -> usize {
-        let i = Self::_partition_kth(grains, k, 0, grains.len() - 1);
-        let t = grains[i].d;
-
-        let mut b = i;
-        for a in (i + 1)..(grains.len()) {
-            if grains[a].d == t {
-                b += 1;
-                grains.swap(a, b);
-            }
-        }
-
-        b
+    pub fn partition(grains: &mut [Self], k: usize, g_init: usize) -> usize {
+        Self::_partition(grains, k, 0, grains.len() - 1, g_init)
     }
 
     /// Finds the smallest index i such that all grains with distance closer to or
     /// equal to the distance of the grain at index i have a multiplicity greater
     /// than or equal to k.
-    pub fn _partition_kth(grains: &mut [Self], k: usize, l: usize, r: usize) -> usize {
+    #[allow(clippy::many_single_char_names)]
+    fn _partition(grains: &mut [Self], k: usize, l: usize, r: usize, g_init: usize) -> usize {
         if l >= r {
-            std::cmp::min(l, r)
+            min(l, r)
         } else {
-            let p = Self::_partition(grains, l, r);
-            let guaranteed = grains
-                .iter()
-                .scan(0, |acc, g| {
-                    *acc += g.multiplicity;
-                    Some(*acc)
-                })
-                .collect::<Vec<_>>();
+            let p = Self::_partition_once(grains, l, r);
 
-            let num_g = guaranteed[p];
+            // The number of guaranteed hits within the first p grains.
+            let g: usize = grains.iter().take(p).map(|g| g.multiplicity).sum();
 
-            match num_g.cmp(&k) {
-                std::cmp::Ordering::Less => Self::_partition_kth(grains, k, p + 1, r),
-                std::cmp::Ordering::Equal => p,
-                std::cmp::Ordering::Greater => {
-                    if (p > 0) && (guaranteed[p - 1] > k) {
-                        Self::_partition_kth(grains, k, l, p - 1)
+            match g.cmp(&(k - g_init)) {
+                Ordering::Equal => p,
+                Ordering::Less => Self::_partition(grains, k, p + 1, r, g_init),
+                Ordering::Greater => {
+                    if (p > 0) && (g > (k + grains[p - 1].multiplicity)) {
+                        Self::_partition(grains, k, l, p - 1, g_init)
                     } else {
                         p
                     }
@@ -291,8 +186,8 @@ impl<'a, T: Send + Sync + Copy, U: Number> Grain<'a, T, U> {
     /// Changes pivot point and swaps elements around so that all elements to left
     /// of pivot are less than or equal to pivot and all elements to right of pivot
     /// are greater than pivot.
-    pub fn _partition(grains: &mut [Self], l: usize, r: usize) -> usize {
-        let pivot = (l + r) / 2;
+    fn _partition_once(grains: &mut [Self], l: usize, r: usize) -> usize {
+        let pivot = l + (r - l) / 2;
         grains.swap(pivot, r);
 
         let (mut a, mut b) = (l, l);
@@ -310,46 +205,13 @@ impl<'a, T: Send + Sync + Copy, U: Number> Grain<'a, T, U> {
     }
 }
 
-/// Field by which we rank elements in priority queue of hits.
-#[derive(Debug)]
-pub struct OrdNumber<U: Number> {
-    /// The number we use to rank elements (distance to query).
-    number: U,
-}
-
-impl<U: Number> PartialEq for OrdNumber<U> {
-    fn eq(&self, other: &Self) -> bool {
-        self.number == other.number
-    }
-}
-
-impl<U: Number> Eq for OrdNumber<U> {}
-
-impl<U: Number> PartialOrd for OrdNumber<U> {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.number.partial_cmp(&other.number)
-    }
-}
-
-impl<U: Number> Ord for OrdNumber<U> {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.partial_cmp(other).unwrap_or_else(|| {
-            unreachable!(
-                "All hits are instances, and
-        therefore each hit has a distance from the query. Since all hits' distances to the
-        query will be represented by the same type, we can always compare them."
-            )
-        })
-    }
-}
-
 #[cfg(test)]
 mod tests {
 
     use distances::vectors::euclidean;
     use symagen::random_data;
 
-    use crate::{cakes::knn::linear, Cakes, PartitionCriteria, VecDataset};
+    use crate::{cakes::knn::linear, knn::tests::sort_hits, Cakes, PartitionCriteria, VecDataset};
 
     #[test]
     fn sieve_v1() {
@@ -369,9 +231,8 @@ mod tests {
         let tree = model.tree();
 
         for k in [100, 10, 1] {
-            let linear_nn = linear::search(tree.data(), query, k, tree.indices());
-            let mut sieve_nn = super::search(tree, query, k);
-            sieve_nn.sort_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap());
+            let linear_nn = sort_hits(linear::search(tree.data(), query, k, tree.indices()));
+            let sieve_nn = sort_hits(super::search(tree, query, k));
 
             assert_eq!(linear_nn, sieve_nn);
         }

--- a/abd-clam/src/cakes/knn/sieve_v2.rs
+++ b/abd-clam/src/cakes/knn/sieve_v2.rs
@@ -372,7 +372,7 @@ mod tests {
     use distances::vectors::euclidean;
     use symagen::random_data;
 
-    use crate::{cakes::knn::linear, Cakes, PartitionCriteria, VecDataset};
+    use crate::{cakes::knn::linear, knn::tests::sort_hits, Cakes, PartitionCriteria, VecDataset};
 
     #[test]
     fn sieve_v2() {
@@ -392,9 +392,8 @@ mod tests {
         let tree = model.tree();
 
         for k in [100, 10, 1] {
-            let linear_nn = linear::search(tree.data(), query, k, tree.indices());
-            let mut sieve_nn = super::search(tree, query, k);
-            sieve_nn.sort_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap());
+            let linear_nn = sort_hits(linear::search(tree.data(), query, k, tree.indices()));
+            let sieve_nn = sort_hits(super::search(tree, query, k));
             assert_eq!(linear_nn, sieve_nn);
         }
     }


### PR DESCRIPTION
In this PR, I have optimized SieveV1, remove the sieve struct altogether and arriving at a relatively clean single function for the search algorithm.

I have also added a wrapper around a priority queue, called `Hits`, to keep track of the `k` best hits during search.

I have also used this new `Hits` struct in linear search, which is now ~4.5x faster than before.

I have attached the current benchmarks (from my mac). The y-axis is `knn-{metric}/{knn::Algorithm}/{k}` and the x-axis is the mean time (in `ms` on a log-scale) for `100` queries.
![knn-bench](https://github.com/URI-ABD/clam/assets/32004868/651a2c5d-5fed-4f01-8806-e8131de31ded)
