### PR TITLE
Feat/serde for cluster

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.21.6
+current_version = 0.21.7
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<dev>\d+))?

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CLAM: Clustered Learning of Approximate Manifolds (v0.21.6)
+# CLAM: Clustered Learning of Approximate Manifolds (v0.21.7)
 
 CLAM is a Rust/Python library for learning approximate manifolds from data.
 It is designed to be fast, memory-efficient, easy to use, and scalable for big data applications.
@@ -10,7 +10,7 @@ This means that the API is not yet stable and breaking changes may occur frequen
 
 ## Usage
 
-CLAM is a library crate so you can add it to your crate using `cargo add abd_clam@0.21.6`.
+CLAM is a library crate so you can add it to your crate using `cargo add abd_clam@0.21.7`.
 
 Here is a simple example of how to use CLAM to perform nearest neighbors search:
 

--- a/abd-clam/Cargo.toml
+++ b/abd-clam/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "abd-clam"
-version = "0.21.6"
+version = "0.21.7"
 authors = [
     "Najib Ishaq <najib_ishaq@zoho.com>",
     "Tom Howard <info@tomhoward.codes>",
@@ -48,12 +48,13 @@ libm = "0.2.7"
 ndarray = { version = "0.15.6", features = ["rayon"] }
 ndarray-npy = "0.8.1"
 memmap2 = "0.7.1"
+# Used for serializing `Cluster`s
+serde = { version = "1.0.164", features = ["derive"] }
+serde_json = { version = "1.0.96", features = ["alloc"] }
 
 [dev-dependencies]
 symagen = { path = "../SyMaGen" }
 criterion = { version = "0.5.1", features = ["html_reports"] }
-serde = { version = "1.0.164", features = ["derive"] }
-serde_json = { version = "1.0.96", features = ["alloc"] }
 log = "0.4.19"
 env_logger = "0.10.0"
 num-format = "0.4.4"

--- a/abd-clam/README.md
+++ b/abd-clam/README.md
@@ -1,4 +1,4 @@
-# CLAM: Clustered Learning of Approximate Manifolds (v0.21.6)
+# CLAM: Clustered Learning of Approximate Manifolds (v0.21.7)
 
 CLAM is a Rust/Python library for learning approximate manifolds from data.
 It is designed to be fast, memory-efficient, easy to use, and scalable for big data applications.
@@ -10,7 +10,7 @@ This means that the API is not yet stable and breaking changes may occur frequen
 
 ## Usage
 
-CLAM is a library crate so you can add it to your crate using `cargo add abd_clam@0.21.6`.
+CLAM is a library crate so you can add it to your crate using `cargo add abd_clam@0.21.7`.
 
 Here is a simple example of how to use CLAM to perform nearest neighbors search:
 

--- a/abd-clam/src/core/cluster/mod.rs
+++ b/abd-clam/src/core/cluster/mod.rs
@@ -10,6 +10,7 @@ mod _cluster;
 mod criteria;
 mod tree;
 
-pub use _cluster::Cluster;
+#[allow(clippy::module_name_repetitions)]
+pub use _cluster::{Cluster, SerializedChildInfo, SerializedCluster};
 pub use criteria::{PartitionCriteria, PartitionCriterion};
 pub use tree::Tree;

--- a/abd-clam/src/lib.rs
+++ b/abd-clam/src/lib.rs
@@ -31,7 +31,7 @@ pub use crate::{
 };
 
 /// The current version of the crate.
-pub const VERSION: &str = "0.21.6";
+pub const VERSION: &str = "0.21.7";
 
 /// Common distance functions and their names for slices of `f32`.
 #[allow(clippy::type_complexity)]

--- a/py-clam/README.md
+++ b/py-clam/README.md
@@ -1,4 +1,4 @@
-# CLAM: Clustered Learning of Approximate Manifolds (v0.21.6)
+# CLAM: Clustered Learning of Approximate Manifolds (v0.21.7)
 
 CLAM is a Rust/Python library for learning approximate manifolds from data.
 It is designed to be fast, memory-efficient, easy to use, and scalable for big data applications.
@@ -11,7 +11,7 @@ This means that the API is not yet stable and breaking changes may occur frequen
 ## Installation
 
 ```shell
-> python3 -m pip install "abd_clam==0.21.6"
+> python3 -m pip install "abd_clam==0.21.7"
 ```
 
 ## Usage

--- a/py-clam/abd_clam/__init__.py
+++ b/py-clam/abd_clam/__init__.py
@@ -21,4 +21,4 @@ from .core import graph_criteria
 from .core import metric
 from .core import space
 
-__version__ = "0.21.6"
+__version__ = "0.21.7"

--- a/py-clam/pyproject.toml
+++ b/py-clam/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "abd-clam"
-version = "0.21.6"
+version = "0.21.7"
 description = "Clustered Learning of Approximate Manifolds"
 authors = [
     "Najib Ishaq <najib_ishaq@zoho.com>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "abd-clam"
-version = "0.21.6"
+version = "0.21.7"
 description = "Clustered Learning of Approximate Manifolds"
 authors = [
     "Najib Ishaq <najib_ishaq@zoho.com>",


### PR DESCRIPTION
Implements basic json serialization for `Cluster`. 

This interface is heavily subject to change in response to the needs imposed by deserializing an entire `Tree` show themselves. 

The struct `SerializedCluster` is used as an intermediate representation to avoid writing a json deserializer directly for `Cluster`. This is primarily due to the fact that we *do not* want to store the actual children of a cluster, just the cluster itself. I also make use of another intermediate structure `SerializedChildInfo` which contains information about the children (if applicable, other wise it's serialized as `None`) like `arg_l/r`, `polar_distance`, and the names of the children.

The second struct is returned by `SerializedCluster::into_partial_cluster` (the naming here is so, so bad) if and only if the original `Cluster` had children. This allows us to not have to store child info directly but also always recover A) a `Cluster` from a `SerializedCluster` and B) any child info if applicable. 

### TODO
- [x] Inverse `Cluster::name` to reconstitute history after deserialization
- [x] A few more basic tests