### PR TITLE
Feat/dataset save load

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.22.1
+current_version = 0.22.2
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<dev>\d+))?

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CLAM: Clustered Learning of Approximate Manifolds (v0.22.1)
+# CLAM: Clustered Learning of Approximate Manifolds (v0.22.2)
 
 CLAM is a Rust/Python library for learning approximate manifolds from data.
 It is designed to be fast, memory-efficient, easy to use, and scalable for big data applications.
@@ -19,7 +19,7 @@ Take a look at the following scripts:
 
 ## Usage
 
-CLAM is a library crate so you can add it to your crate using `cargo add abd_clam@0.22.1`.
+CLAM is a library crate so you can add it to your crate using `cargo add abd_clam@0.22.2`.
 
 Here is a simple example of how to use CLAM to perform nearest neighbors search:
 

--- a/abd-clam/Cargo.toml
+++ b/abd-clam/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "abd-clam"
-version = "0.22.1"
+version = "0.22.2"
 authors = [
     "Najib Ishaq <najib_ishaq@zoho.com>",
     "Tom Howard <info@tomhoward.codes>",
@@ -23,7 +23,7 @@ publish = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-distances = { version = "1.4.0", path = "../distances" }
+distances = { version = "1.4.1", path = "../distances" }
 rayon = "1.8.0"
 
 # Only used for Dataset::choose_unique
@@ -54,6 +54,7 @@ serde_json = { version = "1.0.107", features = ["alloc"] }
 [dev-dependencies]
 symagen = { version = "0.1.3", path = "../SyMaGen" }
 criterion = { version = "0.5.1", features = ["html_reports"] }
+tempdir = "0.3.7"
 
 [[bench]]
 name = "genomic"

--- a/abd-clam/README.md
+++ b/abd-clam/README.md
@@ -1,4 +1,4 @@
-# CLAM: Clustered Learning of Approximate Manifolds (v0.22.1)
+# CLAM: Clustered Learning of Approximate Manifolds (v0.22.2)
 
 CLAM is a Rust/Python library for learning approximate manifolds from data.
 It is designed to be fast, memory-efficient, easy to use, and scalable for big data applications.
@@ -10,7 +10,7 @@ This means that the API is not yet stable and breaking changes may occur frequen
 
 ## Usage
 
-CLAM is a library crate so you can add it to your crate using `cargo add abd_clam@0.22.1`.
+CLAM is a library crate so you can add it to your crate using `cargo add abd_clam@0.22.2`.
 
 Here is a simple example of how to use CLAM to perform nearest neighbors search:
 

--- a/abd-clam/src/lib.rs
+++ b/abd-clam/src/lib.rs
@@ -31,7 +31,7 @@ pub use crate::{
 };
 
 /// The current version of the crate.
-pub const VERSION: &str = "0.22.1";
+pub const VERSION: &str = "0.22.2";
 
 /// Common distance functions and their names for slices of `f32`.
 #[allow(clippy::type_complexity)]

--- a/py-clam/README.md
+++ b/py-clam/README.md
@@ -1,4 +1,4 @@
-# CLAM: Clustered Learning of Approximate Manifolds (v0.22.1)
+# CLAM: Clustered Learning of Approximate Manifolds (v0.22.2)
 
 CLAM is a Rust/Python library for learning approximate manifolds from data.
 It is designed to be fast, memory-efficient, easy to use, and scalable for big data applications.
@@ -11,7 +11,7 @@ This means that the API is not yet stable and breaking changes may occur frequen
 ## Installation
 
 ```shell
-> python3 -m pip install "abd_clam==0.22.1"
+> python3 -m pip install "abd_clam==0.22.2"
 ```
 
 ## Usage

--- a/py-clam/abd_clam/__init__.py
+++ b/py-clam/abd_clam/__init__.py
@@ -21,4 +21,4 @@ from .core import graph_criteria
 from .core import metric
 from .core import space
 
-__version__ = "0.22.1"
+__version__ = "0.22.2"

--- a/py-clam/pyproject.toml
+++ b/py-clam/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "abd-clam"
-version = "0.22.1"
+version = "0.22.2"
 description = "Clustered Learning of Approximate Manifolds"
 authors = [
     "Najib Ishaq <najib_ishaq@zoho.com>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "abd-clam"
-version = "0.22.1"
+version = "0.22.2"
 description = "Clustered Learning of Approximate Manifolds"
 authors = [
     "Najib Ishaq <najib_ishaq@zoho.com>",


### PR DESCRIPTION
Implements `save` and `load` functionality for numeric `vec2d`. Serializes into a simple binary format.

This code is pretty grungy but it's mostly low level file io and byte parsing.

The file format is the obvious one you'd think of:
- `VEC2D` raw text header (Basic read protection. Basically no cost)
- Null-terminated dataset name string
- Cardinality as a u64
- Dimensionality as a u64
- Null-terminated `type_name` string as defined in the `Number` crate
- Row major data. Byte width of the type is NOT encoded. Type width (and thus parsing) is dictated by the constructed type of `V` (see second impl block for numeric-type restricted `vec2d)` May want to include a warning in the constructor. We don't have any kind of underlying type id system for numeric types, so there's not really a clean way of encoding the individual dimension type. This is analogous to the compromise made for the arrow dataset code. 
- A single boolean byte (1 or 0) corresponding to `self.reordering.is_some()`
- If the previous byte is 1, then what follows is a sequence of u64's corresponding to the reordering map

This PR adds `temp_dir` as a dev dependency.