### PR TITLE
Fixing workflows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,7 +54,7 @@ jobs:
             clippy
             rustfmt
       - name: Clam | Tests
-        run: cargo test --release --workspace --exclude automl
+        run: cargo test --release --package abd-clam
 
   python:
     name: Python | Tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,10 @@ on:
     branches-ignore:
       - main
       - master
+  pull_request:
+    branches:
+      - main
+      - master
 
 permissions:
   contents: read

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "abd-clam",
+    "cakes-results",
     # "py-clam",  # TODO: re-enable when py-clam uses maturin to bing to abd-clam
     "distances",
     "rust-automl",

--- a/abd-clam/src/cakes/knn/expanding_threshold.rs
+++ b/abd-clam/src/cakes/knn/expanding_threshold.rs
@@ -146,7 +146,11 @@ mod tests {
 
         for k in [100, 10, 1] {
             let linear_nn = sort_hits(linear::search(tree.data(), query, k, tree.indices()));
+            assert_eq!(linear_nn.len(), k);
+
             let thresholds_nn = sort_hits(super::search(tree, query, k));
+            assert_eq!(thresholds_nn.len(), k);
+
             assert_eq!(linear_nn, thresholds_nn);
         }
     }

--- a/abd-clam/src/cakes/knn/linear.rs
+++ b/abd-clam/src/cakes/knn/linear.rs
@@ -38,14 +38,14 @@ where
 #[cfg(test)]
 mod tests {
 
-    use distances::vectors::euclidean;
+    use distances::{vectors::euclidean, Number};
     use symagen::random_data;
 
     use crate::{Cakes, PartitionCriteria, VecDataset};
 
     #[test]
     fn tiny() {
-        let data = (1..=10).map(|i| vec![i as f32]).collect::<Vec<_>>();
+        let data = (1..=10).map(|i| vec![i.as_f32()]).collect::<Vec<_>>();
         let data = data.iter().map(Vec::as_slice).collect::<Vec<_>>();
         let data = VecDataset::new("tiny".to_string(), data, euclidean::<_, f32>, false);
 

--- a/abd-clam/src/cakes/knn/mod.rs
+++ b/abd-clam/src/cakes/knn/mod.rs
@@ -261,13 +261,13 @@ impl<U: Number> Eq for OrdNumber<U> {}
 
 impl<U: Number> PartialOrd for OrdNumber<U> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.0.partial_cmp(&other.0)
+        Some(self.cmp(other))
     }
 }
 
 impl<U: Number> Ord for OrdNumber<U> {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.partial_cmp(other).unwrap_or(Ordering::Greater)
+        self.0.partial_cmp(&other.0).unwrap_or(Ordering::Greater)
     }
 }
 
@@ -285,13 +285,13 @@ impl<U: Number> Eq for RevNumber<U> {}
 
 impl<U: Number> PartialOrd for RevNumber<U> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        other.0.partial_cmp(&self.0)
+        Some(self.cmp(other))
     }
 }
 
 impl<U: Number> Ord for RevNumber<U> {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.partial_cmp(other).unwrap_or(Ordering::Greater)
+        other.0.partial_cmp(&self.0).unwrap_or(Ordering::Greater)
     }
 }
 

--- a/abd-clam/src/core/cluster/_cluster.rs
+++ b/abd-clam/src/core/cluster/_cluster.rs
@@ -76,11 +76,7 @@ impl<T: Send + Sync + Copy, U: Number> Eq for Cluster<T, U> {}
 
 impl<T: Send + Sync + Copy, U: Number> PartialOrd for Cluster<T, U> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        if self.depth() == other.depth() {
-            self.offset.partial_cmp(&other.offset)
-        } else {
-            self.depth().partial_cmp(&other.depth())
-        }
+        Some(self.cmp(other))
     }
 }
 
@@ -458,17 +454,26 @@ impl<T: Send + Sync + Copy, U: Number> Cluster<T, U> {
             .map(|_| "0")
             .chain(history.iter().map(|&b| if b { "1" } else { "0" }))
             .collect::<Vec<_>>();
-        bin_name
-            .chunks_exact(4)
-            .map(|s| {
-                let [a, b, c, d] = [s[0], s[1], s[2], s[3]];
-                let s = format!("{a}{b}{c}{d}");
-                let Ok(s) = u8::from_str_radix(&s, 2) else {
-                    unreachable!("We know the characters used are only \"0\" and \"1\".")
-                };
-                format!("{s:01x}")
-            })
-            .collect()
+        // bin_name
+        //     .chunks_exact(4)
+        //     .map(|s| {
+        //         let [a, b, c, d] = [s[0], s[1], s[2], s[3]];
+        //         let s = format!("{a}{b}{c}{d}");
+        //         let Ok(s) = u8::from_str_radix(&s, 2) else {
+        //             unreachable!("We know the characters used are only \"0\" and \"1\".")
+        //         };
+        //         format!("{s:01x}")
+        //     })
+        //     .collect()
+        bin_name.chunks_exact(4).fold(String::new(), |mut acc, s| {
+            let [a, b, c, d] = [s[0], s[1], s[2], s[3]];
+            let s = format!("{a}{b}{c}{d}");
+            let Ok(s) = u8::from_str_radix(&s, 2) else {
+                unreachable!("We know the characters used are only \"0\" and \"1\".")
+            };
+            acc.push_str(&format!("{s:01x}"));
+            acc
+        })
     }
 
     /// Converts the hexidecimal representation of cluster history obtained from `Cluster::name`

--- a/abd-clam/src/core/cluster/_cluster.rs
+++ b/abd-clam/src/core/cluster/_cluster.rs
@@ -3,6 +3,7 @@
 //! spaces.
 
 use core::{
+    cmp::Ordering,
     hash::{Hash, Hasher},
     marker::PhantomData,
 };
@@ -75,17 +76,16 @@ impl<T: Send + Sync + Copy, U: Number> PartialEq for Cluster<T, U> {
 impl<T: Send + Sync + Copy, U: Number> Eq for Cluster<T, U> {}
 
 impl<T: Send + Sync + Copy, U: Number> PartialOrd for Cluster<T, U> {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
 impl<T: Send + Sync + Copy, U: Number> Ord for Cluster<T, U> {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        if self.depth() == other.depth() {
-            self.offset.cmp(&other.offset)
-        } else {
-            self.depth().cmp(&other.depth())
+    fn cmp(&self, other: &Self) -> Ordering {
+        match self.depth().cmp(&other.depth()) {
+            Ordering::Equal => self.offset.cmp(&other.offset),
+            ordering => ordering,
         }
     }
 }

--- a/py-clam/tests/test_classifier.py
+++ b/py-clam/tests/test_classifier.py
@@ -37,6 +37,7 @@ class TestSearch(unittest.TestCase):
 
         return score
 
+    @unittest.skipIf(IN_GITHUB_ACTIONS, "Requires disk write access.")
     def test_digits(self):
         digits = load_digits()
 
@@ -49,6 +50,7 @@ class TestSearch(unittest.TestCase):
         )
         assert score >= 0.75, "score on digits dataset was too low."
 
+    @unittest.skipIf(IN_GITHUB_ACTIONS, "Requires disk write access.")
     def test_bullseye(self):
         full_x, full_y = synthetic_data.bullseye(n=256, num_rings=3)
         full_x = helpers.normalize(full_x, mode="gaussian")


### PR DESCRIPTION
This PR:

- Updates github actions to run on pull-requests from forks.
- fixes clippy lints from Rust `v1.73` for implementations of `PartialOrd` and `Ord` traits
- for Rust tests, only runs tests in abd-clam because the other crates have their own workflows.
- for Python tests, skips the classifier tests from py-clam because that implementation was really hacky.