### PR TITLE
Feat: Save/load for tree

### DIFF
--- a/abd-clam/src/core/cluster/_cluster.rs
+++ b/abd-clam/src/core/cluster/_cluster.rs
@@ -884,24 +884,24 @@ mod tests {
         let mut c1 = Cluster::new_root(&data, Some(42));
         c1.history = vec![true, true, false, false, true];
 
-        let (s1, s1_children) = SerializedCluster::from_cluster(&c1);
-        let s1_string = serde_json::to_string(&s1).unwrap();
+        let (original, original_children) = SerializedCluster::from_cluster(&c1);
+        let original_string = serde_json::to_string(&original).unwrap();
 
-        let s2: SerializedCluster = serde_json::from_str(&s1_string).unwrap();
-        assert_eq!(s1.name, s2.name);
-        assert_eq!(s1.seed, s2.seed);
-        assert_eq!(s1.offset, s2.offset);
-        assert_eq!(s1.cardinality, s2.cardinality);
-        assert_eq!(s1.arg_center, s2.arg_center);
-        assert_eq!(s1.arg_radial, s2.arg_radial);
-        assert_eq!(s1.radius_bytes, s2.radius_bytes);
-        assert_eq!(s1.lfd, s2.lfd);
-        assert_eq!(s1.ratios, s2.ratios);
+        let deserialized: SerializedCluster = serde_json::from_str(&original_string).unwrap();
+        assert_eq!(original.name, deserialized.name);
+        assert_eq!(original.seed, deserialized.seed);
+        assert_eq!(original.offset, deserialized.offset);
+        assert_eq!(original.cardinality, deserialized.cardinality);
+        assert_eq!(original.arg_center, deserialized.arg_center);
+        assert_eq!(original.arg_radial, deserialized.arg_radial);
+        assert_eq!(original.radius_bytes, deserialized.radius_bytes);
+        assert_eq!(original.lfd, deserialized.lfd);
+        assert_eq!(original.ratios, deserialized.ratios);
 
-        let c2 = s2.into_partial_cluster();
+        let c2 = deserialized.into_partial_cluster();
 
         assert_eq!(c1, c2);
-        assert!(s1_children.is_none());
+        assert!(original_children.is_none());
     }
 
     #[test]

--- a/abd-clam/src/core/cluster/_cluster.rs
+++ b/abd-clam/src/core/cluster/_cluster.rs
@@ -656,17 +656,11 @@ pub struct SerializedCluster {
     pub lfd: f64,
     /// The `Cluster`'s ratios
     pub ratios: Option<Ratios>,
-    // /// Serialized information about the cluster's immediate children, if applicable
-    // pub children: Option<SerializedChildren>,
 }
 
 /// Serialized information about a given `Cluster`'s children
 #[derive(Serialize, Deserialize)]
 pub struct SerializedChildren {
-    /// The encoded history of the left child
-    pub left_name: String,
-    /// The encoded history of the right child
-    pub right_name: String,
     /// The left pole of the `Cluster`
     pub arg_l: usize,
     /// The right pole of the `Cluster`
@@ -699,15 +693,12 @@ impl SerializedCluster {
         // the tree and serialize manually
         let children = cluster.children.as_ref().map(
             |Children {
-                 left,
-                 right,
                  arg_l,
                  arg_r,
                  polar_distance,
+                 ..
              }| {
                 SerializedChildren {
-                    left_name: left.name(),
-                    right_name: right.name(),
                     arg_l: *arg_l,
                     arg_r: *arg_r,
                     polar_distance_bytes: polar_distance.to_le_bytes(),

--- a/abd-clam/src/core/cluster/tree.rs
+++ b/abd-clam/src/core/cluster/tree.rs
@@ -61,6 +61,7 @@ impl<I: Instance, U: Number, D: Dataset<I, U>> Tree<I, U, D> {
     #[must_use]
     pub fn partition(mut self, criteria: &PartitionCriteria<U>) -> Self {
         self.root = self.root.partition(&mut self.data, criteria);
+        self.depth = self.root.max_leaf_depth();
         self
     }
 
@@ -307,9 +308,7 @@ mod tests {
         tree1: &Tree<I, U, VecDataset<I, U>>,
         tree2: &Tree<I, U, VecDataset<I, U>>,
     ) {
-        // TODO: (OWM) Right now tree depths are never actually recalculated after partitioning, so `depth` is always
-        // zero on a normal tree. This is not the case with a recovered tree.
-        // assert_eq!(tree1.depth, tree2.depth, "Tree depths inequal");
+        assert_eq!(tree1.depth, tree2.depth, "Tree depths inequal");
         assert_clusters_equal(&tree1.root, &tree1.data, &tree2.root, &tree2.data);
     }
 

--- a/abd-clam/src/core/cluster/tree.rs
+++ b/abd-clam/src/core/cluster/tree.rs
@@ -2,7 +2,7 @@
 
 use core::marker::PhantomData;
 use std::{
-    fs::{DirBuilder, File},
+    fs::{create_dir, File},
     io::{Read, Write},
     path::{Path, PathBuf},
 };
@@ -97,24 +97,21 @@ impl<I: Instance, U: Number, D: Dataset<I, U>> Tree<I, U, D> {
     /// Errors out on any directory or file creation issues
     #[allow(clippy::missing_panics_doc)]
     pub fn save(&self, path: &Path) -> Result<(), String> {
-        // Create our directory if needed
-        let dirbuilder = DirBuilder::new();
-
         if !path.exists() {
             return Err("Given path does not exist".to_string());
         }
 
         // Create cluster directory
         let cluster_path = path.join("clusters");
-        dirbuilder.create(&cluster_path).map_err(|e| e.to_string())?;
+        create_dir(&cluster_path).map_err(|e| e.to_string())?;
 
         // Create childinfo directory
         let childinfo_path = path.join("childinfo");
-        dirbuilder.create(&childinfo_path).map_err(|e| e.to_string())?;
+        create_dir(&childinfo_path).map_err(|e| e.to_string())?;
 
         // Create dataset directory
         let dataset_dir = path.join("dataset");
-        dirbuilder.create(&dataset_dir).map_err(|e| e.to_string())?;
+        create_dir(&dataset_dir).map_err(|e| e.to_string())?;
 
         // List of leaf clusters (Used for loading in the tree later)
         let mut leaves: Vec<String> = vec![];

--- a/abd-clam/src/core/cluster/tree.rs
+++ b/abd-clam/src/core/cluster/tree.rs
@@ -91,7 +91,7 @@ impl<I: Instance, U: Number, D: Dataset<I, U>> Tree<I, U, D> {
     ///      childinfo/  <-- Information about clusters immediate children.
     ///      dataset/    <-- The serialized dataset.
     ///      leaves.json <-- A json file of leaf names.
-    /// ````
+    /// ```
     ///
     /// # Errors
     /// Errors out on any directory or file creation issues
@@ -99,10 +99,6 @@ impl<I: Instance, U: Number, D: Dataset<I, U>> Tree<I, U, D> {
     pub fn save(&self, path: &Path) -> Result<(), String> {
         // Create our directory if needed
         let dirbuilder = DirBuilder::new();
-
-        if !path.exists() {
-            dirbuilder.create(path).map_err(|e| e.to_string())?;
-        }
 
         // Create cluster directory
         let cluster_path = path.join("clusters");
@@ -300,7 +296,6 @@ mod tests {
         distances::vectors::euclidean(x, y)
     }
 
-    //I: Instance, U: Number, D: Dataset<I, U>
     fn assert_trees_equal<I: Instance, U: Number>(
         tree1: &Tree<I, U, VecDataset<I, U>>,
         tree2: &Tree<I, U, VecDataset<I, U>>,

--- a/abd-clam/src/core/cluster/tree.rs
+++ b/abd-clam/src/core/cluster/tree.rs
@@ -286,7 +286,7 @@ fn recover_serialized_childinfo(path: PathBuf) -> Result<SerializedChildren, Str
 #[cfg(test)]
 mod tests {
     use distances::Number;
-    use std::env::temp_dir;
+    use tempdir::TempDir;
 
     use crate::{
         core::cluster::{Cluster, _cluster::Children},
@@ -384,18 +384,13 @@ mod tests {
         let partition_criteria = PartitionCriteria::new(true).with_max_depth(3).with_min_cardinality(1);
         let raw_tree = Tree::new(data, Some(42)).partition(&partition_criteria);
 
-        let tree_path = temp_dir().join("tiny_tree");
-
-        // Delete the path if it exists
-        if tree_path.exists() {
-            std::fs::remove_dir_all(&tree_path).unwrap();
-        }
+        let tree_path = TempDir::new("tree_tiny").unwrap();
 
         // Save the tree
-        raw_tree.save(&tree_path).unwrap();
+        raw_tree.save(&tree_path.path()).unwrap();
 
         // Recover the tree
-        let recovered_tree = Tree::<Vec<f32>, f32, VecDataset<_, _>>::load(&tree_path, metric, false).unwrap();
+        let recovered_tree = Tree::<Vec<f32>, f32, VecDataset<_, _>>::load(&tree_path.path(), metric, false).unwrap();
 
         // Assert recovering was successful
         assert_trees_equal(&raw_tree, &recovered_tree);
@@ -413,18 +408,13 @@ mod tests {
 
         let raw_tree = Tree::new(data, Some(42)).partition(&partition_criteria);
 
-        let tree_path = temp_dir().join("medium_tree");
-
-        // Delete the path if it exists
-        if tree_path.exists() {
-            std::fs::remove_dir_all(&tree_path).unwrap();
-        }
+        let tree_path = TempDir::new("tree_medium").unwrap();
 
         // Save the tree
-        raw_tree.save(&tree_path).unwrap();
+        raw_tree.save(&tree_path.path()).unwrap();
 
         // Recover the tree
-        let recovered_tree = Tree::<Vec<f32>, f32, VecDataset<_, _>>::load(&tree_path, metric, false).unwrap();
+        let recovered_tree = Tree::<Vec<f32>, f32, VecDataset<_, _>>::load(&tree_path.path(), metric, false).unwrap();
 
         // Assert recovering was successful
         assert_trees_equal(&raw_tree, &recovered_tree);
@@ -442,18 +432,13 @@ mod tests {
 
         let raw_tree = Tree::new(data, Some(42)).partition(&partition_criteria);
 
-        let tree_path = temp_dir().join("medium_tree");
-
-        // Delete the path if it exists
-        if tree_path.exists() {
-            std::fs::remove_dir_all(&tree_path).unwrap();
-        }
+        let tree_path = TempDir::new("tree_large").unwrap();
 
         // Save the tree
-        raw_tree.save(&tree_path).unwrap();
+        raw_tree.save(&tree_path.path()).unwrap();
 
         // Recover the tree
-        let recovered_tree = Tree::<Vec<f32>, f32, VecDataset<_, _>>::load(&tree_path, metric, false).unwrap();
+        let recovered_tree = Tree::<Vec<f32>, f32, VecDataset<_, _>>::load(&tree_path.path(), metric, false).unwrap();
 
         // Assert recovering was successful
         assert_trees_equal(&raw_tree, &recovered_tree);

--- a/abd-clam/src/core/cluster/tree.rs
+++ b/abd-clam/src/core/cluster/tree.rs
@@ -91,10 +91,9 @@ impl<I: Instance, U: Number, D: Dataset<I, U>> Tree<I, U, D> {
         // General structure
         // user_given_path/
         //      clusters/   <-- Clusters are serialized using their hex name.
-        //                      Leaves have their name prepended with 'l_'.
-        //      childinfo/  <-- Information about clusters immediate children
-        //      dataset/    <-- The serialized dataset
-        //      leaves.json <-- A json file of leaf names
+        //      childinfo/  <-- Information about clusters immediate children.
+        //      dataset/    <-- The serialized dataset.
+        //      leaves.json <-- A json file of leaf names.
         // Create our directory
         let dirbuilder = DirBuilder::new();
         dirbuilder.create(path).map_err(|e| e.to_string())?;

--- a/abd-clam/src/core/cluster/tree.rs
+++ b/abd-clam/src/core/cluster/tree.rs
@@ -1,10 +1,17 @@
 //! A `Tree` represents a hierarchy of "similar" instances from a metric-`Space`.
 
 use core::marker::PhantomData;
+use std::{
+    fs::{DirBuilder, File},
+    io::Write,
+    path::Path,
+};
 
 use distances::Number;
 
 use crate::{Cluster, Dataset, Instance, PartitionCriteria};
+
+use super::SerializedCluster;
 
 /// A `Tree` represents a hierarchy of `Cluster`s, i.e. "similar" instances
 /// from a metric-`Space`.
@@ -71,5 +78,80 @@ impl<I: Instance, U: Number, D: Dataset<I, U>> Tree<I, U, D> {
     /// The radius of the root of the `Tree`.
     pub const fn radius(&self) -> U {
         self.root.radius
+    }
+
+    /// Saves a tree to a given location
+    ///
+    /// The path given will point to a newly created folder which will
+    /// store all necessary data for reconstruction.
+    ///
+    /// # Errors
+    /// .
+    #[allow(clippy::missing_panics_doc)]
+    pub fn save(&self, path: &Path) -> Result<(), String> {
+        // General structure
+        // user_given_path/
+        //      clusters/ <-- Clusters are serialized using their hex name.
+        //                     Leaves have their name prepended with 'l_'
+        //      dataset/
+
+        // Create our directory
+        let dirbuilder = DirBuilder::new();
+        dirbuilder.create(path).map_err(|e| e.to_string())?;
+
+        // Create cluster directory
+        let cluster_path = path.join("clusters");
+        dirbuilder.create(cluster_path).map_err(|e| e.to_string())?;
+
+        // Traverse the tree, serializing each cluster
+        let mut stack = vec![&self.root];
+        while let Some(cur) = stack.pop() {
+            // Our filename is dynamic based on if the cluster is a leaf or not
+            let mut filename: String = String::new();
+
+            // If the cluster is a parent, we push the children to the queue
+            if !cur.is_leaf() {
+                // Unwrapping is justified here because we validated that the cluster
+                // is a leaf before reaching this code
+                #[allow(clippy::unwrap_used)]
+                let [l, r] = cur.children().unwrap();
+                stack.push(l);
+                stack.push(r);
+
+                // Append "l_" to filename if the node is a leaf
+                filename += "l_";
+            }
+
+            // Finalize the filename
+            filename += &cur.name();
+
+            // Create the path to and open the serialized cluster file
+            let node_path = path.join(filename);
+            let mut file = File::create(node_path).map_err(|e| e.to_string())?;
+
+            // Write out the serialized cluster
+            let serialized = SerializedCluster::from_cluster(cur);
+            let serialized = serde_json::to_string(&serialized).map_err(|e| e.to_string())?;
+            write!(file, "{serialized}").map_err(|e| e.to_string())?;
+        }
+
+        // Serialize our dataset
+        let dataset_path = path.join("dataset");
+        dirbuilder.create(dataset_path).map_err(|e| e.to_string())?;
+        self.data.save(path)?;
+
+        Ok(())
+    }
+
+    /// # Errors
+    pub fn load(_path: &Path) -> Result<Self, String> {
+        // Load the dataset in
+
+        // Load the root in
+
+        // Load the leaves into a vec
+
+        // for each leaf { build out to that leaf }
+        todo!()
     }
 }

--- a/abd-clam/src/core/cluster/tree.rs
+++ b/abd-clam/src/core/cluster/tree.rs
@@ -173,15 +173,12 @@ impl<I: Instance, U: Number, D: Dataset<I, U>> Tree<I, U, D> {
         let mut boxed_root = Box::new(root);
 
         // Now, for each leaf, we build out the tree up to that leaf
+        // This is bounded O(nd) where n is the # of nodes, d is the depth of the tree
         for leaf in leaf_names {
             let mut cur = &mut boxed_root;
             let leaf_history = Cluster::<U>::name_to_history(&leaf);
 
-            for step in 0..leaf_history.len() {
-                if step == 0 {
-                    continue;
-                }
-
+            for step in 1..leaf_history.len() {
                 let branch = leaf_history[step];
 
                 if cur.children.is_none() {

--- a/abd-clam/src/core/cluster/tree.rs
+++ b/abd-clam/src/core/cluster/tree.rs
@@ -97,9 +97,12 @@ impl<I: Instance, U: Number, D: Dataset<I, U>> Tree<I, U, D> {
     /// Errors out on any directory or file creation issues
     #[allow(clippy::missing_panics_doc)]
     pub fn save(&self, path: &Path) -> Result<(), String> {
-        // Create our directory
+        // Create our directory if needed
         let dirbuilder = DirBuilder::new();
-        dirbuilder.create(path).map_err(|e| e.to_string())?;
+
+        if !path.exists() {
+            dirbuilder.create(path).map_err(|e| e.to_string())?;
+        }
 
         // Create cluster directory
         let cluster_path = path.join("clusters");

--- a/abd-clam/src/core/cluster/tree.rs
+++ b/abd-clam/src/core/cluster/tree.rs
@@ -120,16 +120,14 @@ impl<I: Instance, U: Number, D: Dataset<I, U>> Tree<I, U, D> {
         while let Some(cur) = stack.pop() {
             let filename: String = cur.name();
 
-            // If the cluster is a parent, we push the children to the queue
-            if cur.is_leaf() {
-                leaves.push(filename.clone());
-            } else {
-                // Unwrapping is justified here because we validated that the cluster
-                // is a leaf before reaching this code
-                #[allow(clippy::unwrap_used)]
-                let [l, r] = cur.children().unwrap();
-                stack.push(l);
-                stack.push(r);
+            match &cur.children {
+                Some(Children { left, right, .. }) => {
+                    stack.push(left);
+                    stack.push(right);
+                }
+                None => {
+                    leaves.push(filename.clone());
+                }
             }
 
             // Write out the serialized cluster

--- a/abd-clam/src/core/dataset/vec2d.rs
+++ b/abd-clam/src/core/dataset/vec2d.rs
@@ -21,7 +21,6 @@ use super::Instance;
 ///
 /// - `T`: The type of the instances in the `Dataset`.
 /// - `U`: The type of the distance values between instances.
-#[derive(Debug)]
 pub struct VecDataset<I: Instance, U: Number> {
     /// The name of the dataset.
     pub(crate) name: String,

--- a/abd-clam/src/core/dataset/vec2d.rs
+++ b/abd-clam/src/core/dataset/vec2d.rs
@@ -21,6 +21,7 @@ use super::Instance;
 ///
 /// - `T`: The type of the instances in the `Dataset`.
 /// - `U`: The type of the distance values between instances.
+#[derive(Debug)]
 pub struct VecDataset<I: Instance, U: Number> {
     /// The name of the dataset.
     pub(crate) name: String,


### PR DESCRIPTION
## TODO
- [x] Recover depth info
- [x] Overall cleanup
- [x] Docs for all new funcs
- [x] Comments
- [x] Basic randomized testing
- [x] General improvements; Removal of constant values where applicable

## Notes
- Might be able to cut significant time by keeping track of allocated clusters. Currently we just traverse which amounts to an expensive noop
- We should have a slightly more robust way of comparing equality between two cluster hierarchies 
- Do we ever plan to expand to parametrized cluster partitioning? I.e. trinary, quaternary, etc.
- **BUG**: `tree.depth` is always zero because we never actually recalculate it after partitioning, lol. Once that gets fixed we need to update the `assert_trees_equal` function.