### PR TITLE
Added support for metadata in the `VecDataset` struct.

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.25.5
+current_version = 0.26.0
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<dev>\d+))?

--- a/abd-clam/Cargo.toml
+++ b/abd-clam/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "abd-clam"
-version = "0.25.5"
+version = "0.26.0"
 authors = [
     "Najib Ishaq <najib_ishaq@zoho.com>",
     "Tom Howard <info@tomhoward.codes>",

--- a/abd-clam/README.md
+++ b/abd-clam/README.md
@@ -1,4 +1,4 @@
-# CLAM: Clustering, Learning and Approximation with Manifolds (v0.25.5)
+# CLAM: Clustering, Learning and Approximation with Manifolds (v0.26.0)
 
 The Rust implementation of CLAM.
 
@@ -7,7 +7,7 @@ This means that the API is not yet stable and breaking changes may occur frequen
 
 ## Usage
 
-CLAM is a library crate so you can add it to your crate using `cargo add abd_clam@0.25.5`.
+CLAM is a library crate so you can add it to your crate using `cargo add abd_clam@0.26.0`.
 
 ### Cakes: Nearest Neighbor Search
 

--- a/abd-clam/benches/genomic.rs
+++ b/abd-clam/benches/genomic.rs
@@ -37,7 +37,7 @@ fn genomic(c: &mut Criterion) {
 
         println!("Building cakes for {metric_name} ...");
         let data_name = format!("{metric_name}-{cardinality}");
-        let dataset = VecDataset::new(data_name, data.clone(), metric, true);
+        let dataset = VecDataset::<_, _, bool>::new(data_name, data.clone(), metric, true, None);
         let criteria = PartitionCriteria::default();
         let cakes = Cakes::new(dataset, Some(seed), &criteria);
 

--- a/abd-clam/benches/knn-search.rs
+++ b/abd-clam/benches/knn-search.rs
@@ -32,7 +32,7 @@ fn cakes(c: &mut Criterion) {
             .throughput(Throughput::Elements(1))
             .plot_config(PlotConfiguration::default().summary_scale(AxisScale::Logarithmic));
 
-        let dataset = VecDataset::new("knn".to_string(), data.clone(), metric, false);
+        let dataset = VecDataset::<_, _, bool>::new("knn".to_string(), data.clone(), metric, false, None);
         let criteria = PartitionCriteria::default();
         let cakes = Cakes::new(dataset, Some(seed), &criteria);
 

--- a/abd-clam/benches/knn-vs-rnn.rs
+++ b/abd-clam/benches/knn-vs-rnn.rs
@@ -31,7 +31,7 @@ fn cakes(c: &mut Criterion) {
             .throughput(Throughput::Elements(num_queries as u64))
             .plot_config(PlotConfiguration::default().summary_scale(AxisScale::Logarithmic));
 
-        let dataset = VecDataset::new("knn".to_string(), data.clone(), metric, false);
+        let dataset = VecDataset::<_, _, bool>::new("knn".to_string(), data.clone(), metric, false, None);
         let criteria = PartitionCriteria::default();
         let cakes = Cakes::new(dataset, Some(seed), &criteria);
 

--- a/abd-clam/benches/rnn-search.rs
+++ b/abd-clam/benches/rnn-search.rs
@@ -29,7 +29,7 @@ fn cakes(c: &mut Criterion) {
             .throughput(Throughput::Elements(num_queries as u64))
             .plot_config(PlotConfiguration::default().summary_scale(AxisScale::Logarithmic));
 
-        let dataset = VecDataset::new("rnn".to_string(), data.clone(), metric, false);
+        let dataset = VecDataset::<_, _, bool>::new("rnn".to_string(), data.clone(), metric, false, None);
         let criteria = PartitionCriteria::default();
         let cakes = Cakes::new(dataset, Some(seed), &criteria);
 

--- a/abd-clam/src/cakes/sharded.rs
+++ b/abd-clam/src/cakes/sharded.rs
@@ -233,13 +233,14 @@ mod tests {
             random_data::random_tabular_seedable::<f32>(num_queries, dimensionality, min_val, max_val, seed + 1);
 
         let name = format!("test-full");
-        let data = VecDataset::new(name, data_vec.clone(), metric, false);
+        let data = VecDataset::<_, _, bool>::new(name, data_vec.clone(), metric, false, None);
         let cakes = SingleShard::new(data, Some(seed), &PartitionCriteria::default());
 
         let num_shards = 10;
         let max_cardinality = cardinality / num_shards;
         let name = format!("test-sharded");
-        let data_shards = VecDataset::new(name, data_vec, metric, false).make_shards(max_cardinality);
+        let data_shards =
+            VecDataset::<_, _, bool>::new(name, data_vec, metric, false, None).make_shards(max_cardinality);
         let shards = data_shards
             .into_iter()
             .map(|d| SingleShard::new(d, Some(seed), &PartitionCriteria::default()))

--- a/abd-clam/src/lib.rs
+++ b/abd-clam/src/lib.rs
@@ -32,4 +32,4 @@ pub use crate::{
 };
 
 /// The current version of the crate.
-pub const VERSION: &str = "0.25.5";
+pub const VERSION: &str = "0.26.0";

--- a/abd-clam/tests/test_cluster.rs
+++ b/abd-clam/tests/test_cluster.rs
@@ -9,6 +9,7 @@ fn tiny() {
     let mut data = utils::gen_dataset_from(
         vec![vec![0., 0., 0.], vec![1., 1., 1.], vec![2., 2., 2.], vec![3., 3., 3.]],
         utils::euclidean::<f32, f32>,
+        Some(vec![true, true, false, false]),
     );
     let partition_criteria = PartitionCriteria::default();
     let root = Cluster::new_root(&data, Some(42)).partition(&mut data, &partition_criteria);
@@ -60,7 +61,7 @@ fn medium() {
     check_subtree(&root, &data);
 }
 
-fn check_subtree(root: &Cluster<f32>, data: &VecDataset<Vec<f32>, f32>) {
+fn check_subtree(root: &Cluster<f32>, data: &VecDataset<Vec<f32>, f32, bool>) {
     for c in root.subtree() {
         assert!(c.cardinality() > 0, "Cardinality must be positive.");
         assert!(c.radius() >= 0., "Radius must be non-negative.");
@@ -80,6 +81,7 @@ fn serialization() {
     let data = utils::gen_dataset_from(
         vec![vec![0., 0., 0.], vec![1., 1., 1.], vec![2., 2., 2.], vec![3., 3., 3.]],
         utils::euclidean::<f32, f32>,
+        Some(vec![true, true, false, false]),
     );
 
     let original = Cluster::new_root(&data, Some(42));
@@ -103,7 +105,7 @@ fn serialization() {
 #[test]
 fn ratios() {
     // Generate some tree from a small dataset
-    let data = utils::gen_dataset_from(vec![vec![10.], vec![1.], vec![3.]], utils::euclidean::<f32, f32>);
+    let data = utils::gen_dataset_from(vec![vec![10.], vec![1.], vec![3.]], utils::euclidean::<f32, f32>, None);
 
     let partition_criteria = PartitionCriteria::default();
     let root = Tree::new(data, Some(42))

--- a/abd-clam/tests/test_search_variants.rs
+++ b/abd-clam/tests/test_search_variants.rs
@@ -10,7 +10,8 @@ mod utils;
 #[test]
 fn linear() {
     let data = (-10..=10).map(|i| vec![i.as_f32()]).collect::<Vec<_>>();
-    let data = utils::gen_dataset_from(data, utils::euclidean);
+    let metadata = data.iter().map(|i| i[0] > 0.0).collect::<Vec<_>>();
+    let data = utils::gen_dataset_from(data, utils::euclidean, Some(metadata));
 
     let query = &vec![0.0];
 

--- a/abd-clam/tests/test_tree.rs
+++ b/abd-clam/tests/test_tree.rs
@@ -20,6 +20,7 @@ fn leaf_indices() {
             vec![0.],
         ],
         utils::euclidean::<f32, f32>,
+        None,
     );
     let partition_criteria = PartitionCriteria::default();
 
@@ -45,6 +46,7 @@ fn reordering() {
             vec![0.],
         ],
         utils::euclidean::<f32, f32>,
+        None,
     );
     let partition_criteria = PartitionCriteria::default();
 
@@ -88,9 +90,9 @@ fn save_load() {
 /// Asserts that two clusters are equal.
 fn assert_subtree_equal<I: Instance, U: Number>(
     raw_cluster: &Cluster<U>,
-    raw_data: &VecDataset<I, U>,
+    raw_data: &VecDataset<I, U, bool>,
     rec_cluster: &Cluster<U>,
-    rec_data: &VecDataset<I, U>,
+    rec_data: &VecDataset<I, U, bool>,
     metric: fn(&I, &I) -> U,
 ) {
     // Assert their cardinalities

--- a/abd-clam/tests/utils.rs
+++ b/abd-clam/tests/utils.rs
@@ -41,19 +41,20 @@ pub fn gen_dataset(
     dimensionality: usize,
     seed: u64,
     metric: fn(&Vec<f32>, &Vec<f32>) -> f32,
-) -> VecDataset<Vec<f32>, f32> {
+) -> VecDataset<Vec<f32>, f32, bool> {
     let data = symagen::random_data::random_tabular_seedable::<f32>(cardinality, dimensionality, -1., 1., seed);
     let name = "test".to_string();
-    VecDataset::new(name, data, metric, false)
+    VecDataset::new(name, data, metric, false, None)
 }
 
 /// Generate a dataset from the given data.
 pub fn gen_dataset_from<T: Number, U: Number>(
     data: Vec<Vec<T>>,
     metric: fn(&Vec<T>, &Vec<T>) -> U,
-) -> VecDataset<Vec<T>, U> {
+    metadata: Option<Vec<bool>>,
+) -> VecDataset<Vec<T>, U, bool> {
     let name = "test".to_string();
-    VecDataset::new(name, data, metric, false)
+    VecDataset::new(name, data, metric, false, metadata)
 }
 
 /// Compute the recall of the nearest neighbors found.

--- a/cakes-results/src/knn_reports.rs
+++ b/cakes-results/src/knn_reports.rs
@@ -152,13 +152,19 @@ fn make_reports(
             1_000_000
         };
 
-        let shards = VecDataset::new(dataset.name().to_string(), train_data, metric, false)
-            .make_shards(max_cardinality);
+        let shards = VecDataset::<_, _, bool>::new(
+            dataset.name().to_string(),
+            train_data,
+            metric,
+            false,
+            None,
+        )
+        .make_shards(max_cardinality);
         let mut cakes = Cakes::new_randomly_sharded(shards, seed, &PartitionCriteria::default());
         cakes.auto_tune_knn(tuning_k, tuning_depth);
         cakes
     } else {
-        let data = VecDataset::new(dataset.name().to_string(), train_data, metric, false);
+        let data = VecDataset::new(dataset.name().to_string(), train_data, metric, false, None);
         let mut cakes = Cakes::new(data, seed, &PartitionCriteria::default());
         cakes.auto_tune_knn(tuning_k, tuning_depth);
         cakes

--- a/cakes-results/src/scaling_reports.rs
+++ b/cakes-results/src/scaling_reports.rs
@@ -212,7 +212,7 @@ pub fn make_reports(
         );
 
         let data_name = format!("{}-{}", dataset.name(), multiplier + 1);
-        let data = VecDataset::new(data_name, data, metric, false);
+        let data = VecDataset::new(data_name, data, metric, false, None);
         let criteria = PartitionCriteria::default();
 
         let start = Instant::now();
@@ -310,7 +310,7 @@ pub fn make_reports(
 /// * A vector of the hits for each query.
 /// * The throughput of the algorithm.
 fn measure_algorithm<'a>(
-    cakes: &'a Cakes<Vec<f32>, f32, VecDataset<Vec<f32>, f32>>,
+    cakes: &'a Cakes<Vec<f32>, f32, VecDataset<Vec<f32>, f32, bool>>,
     queries: &'a [&Vec<f32>],
     k: usize,
     algorithm: knn::Algorithm,


### PR DESCRIPTION
Also:

- Added example for getting metadata of search results in the README.
- Implemented the `Instance` trait for all `Number` types for use as metadata. For example, one can use:
  - `bool`, `u16` or any integer type for labels.
  - `f32` and `f64` as scores in regression.
  - `String` for headers of sequences.
  - Any arbitrary type that implements `Instance` can be used as well.