### PR TITLE
Making MetaMLScorer public

### DIFF
--- a/crates/abd-clam/src/lib.rs
+++ b/crates/abd-clam/src/lib.rs
@@ -27,7 +27,7 @@ pub use crate::{
     core::{
         cluster::{Cluster, PartitionCriteria, PartitionCriterion, Tree},
         dataset::{Dataset, Instance, VecDataset},
-        graph::{Edge, Graph},
+        graph::{criteria::MetaMLScorer, Edge, Graph},
     },
 };
 


### PR DESCRIPTION
Makes the MetaMLScorer type public so that I can use it in my visualization when building graph