### PR TITLE
CI: Updated tests workflow to use earthly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   publish:
+    if: github.repository == 'URI-ABD/clam'
     strategy:
       matrix:
         package: [abd-clam, distances, SyMaGen]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,7 @@ jobs:
 
   tests:
     needs: pre-commit
+    name: Earthly | Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -44,22 +45,3 @@ jobs:
           version: v0.7.8
       - name: Test
         run: earthly +test
-
-  # rust:
-  #   name: Rust | Tests
-  #   needs: pre-commit
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       # TODO: Add macos-latest after figuring cc linker issue for symagen in github actions
-  #       os: ["ubuntu-latest", "windows-latest", ] # "macos-latest"]
-  #       rust: ["stable"]
-  #   runs-on: ${{ matrix.os }}
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Setup | Rust
-  #       uses: actions-rust-lang/setup-rust-toolchain@v1
-  #       with:
-  #         toolchain: ${{ matrix.rust }}
-  #     - name: Clam | Tests
-  #       run: cargo test --release --package abd-clam

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,26 +29,37 @@ jobs:
           components: |
             clippy
             rustfmt
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
       - uses: pre-commit/action@v3.0.0
 
-  rust:
-    name: Rust | Tests
+  tests:
     needs: pre-commit
-    strategy:
-      fail-fast: false
-      matrix:
-        # TODO: Add macos-latest after figuring cc linker issue for symagen in github actions
-        os: ["ubuntu-latest", "windows-latest", ] # "macos-latest"]
-        rust: ["stable"]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Setup | Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: earthly/actions-setup@v1
         with:
-          toolchain: ${{ matrix.rust }}
-      - name: Clam | Tests
-        run: cargo test --release --package abd-clam
+          version: v0.7.8
+      - name: Test
+        run: earthly +test
+
+  # rust:
+  #   name: Rust | Tests
+  #   needs: pre-commit
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       # TODO: Add macos-latest after figuring cc linker issue for symagen in github actions
+  #       os: ["ubuntu-latest", "windows-latest", ] # "macos-latest"]
+  #       rust: ["stable"]
+  #   runs-on: ${{ matrix.os }}
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Setup | Rust
+  #       uses: actions-rust-lang/setup-rust-toolchain@v1
+  #       with:
+  #         toolchain: ${{ matrix.rust }}
+  #     - name: Clam | Tests
+  #       run: cargo test --release --package abd-clam


### PR DESCRIPTION
This gives us an exact replica of the testing environment in github actions as we have locally.