### PR TITLE
Added random vector generation within n-dim sphere

### DIFF
--- a/crates/SyMaGen/src/augmentation.rs
+++ b/crates/SyMaGen/src/augmentation.rs
@@ -21,7 +21,7 @@ pub fn augment_data(data: &[Vec<f32>], multiplier: usize, error: f32) -> Vec<Vec
 
     data.par_iter()
         .flat_map(|point| {
-            let perturbations = random_data::random_tabular_floats(
+            let perturbations = random_data::random_tabular(
                 multiplier,
                 dimensionality,
                 1.0 - dimensional_error,
@@ -45,10 +45,8 @@ pub fn augment_data(data: &[Vec<f32>], multiplier: usize, error: f32) -> Vec<Vec
 
 #[cfg(test)]
 mod tests {
-    use rand::prelude::*;
-
     use crate::augmentation::augment_data;
-    use crate::random_data::random_tabular_floats;
+    use crate::random_data::random_tabular_seedable;
 
     #[test]
     fn tiny() {
@@ -60,8 +58,7 @@ mod tests {
 
     #[test]
     fn big() {
-        let mut rng = rand::rngs::StdRng::seed_from_u64(42);
-        let data = random_tabular_floats(10000, 20, 0.1, 100.1, &mut rng);
+        let data = random_tabular_seedable(10000, 20, 0.1, 100.1, 42);
         let augmented_data = augment_data(&data, 10, 0.2);
         assert_eq!(110000, augmented_data.len());
 

--- a/crates/SyMaGen/src/random_data.rs
+++ b/crates/SyMaGen/src/random_data.rs
@@ -96,8 +96,23 @@ pub fn random_string(cardinality: usize, min_len: usize, max_len: usize, alphabe
 /// # Returns:
 ///
 /// * `Vec<T>`: the generated point
-pub fn n_ball<T: Number, R: Rng>(dim: usize, _radius: f64, rng: &mut R) -> Vec<T> {
-    let _angles: Vec<T> = (0..dim).map(|_| T::next_random(rng) % T::from(PI)).collect();
+pub fn n_ball<R: Rng>(_dim: usize, radius: f64, _rng: &mut R) -> Vec<f64> {
+    // let _angles: Vec<f64> = (0..dim).map(|_| f64::next_random(rng) % f64::from(PI)).collect();
+    // let angles = random_tabular(1,dim, 0, 2.*PI,  &mut 42);
+    let angles = [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
 
-    [T::from(0.1)].to_vec()
+    let sine_products = angles.iter().scan(1., |sine_product, &x| {
+        // each iteration, we'll multiply the state by the element ...
+        *sine_product *= f64::sin(x);
+        Some(*sine_product)
+    });
+
+    let cosines = angles.iter().map(|&x| f64::cos(x)).collect::<Vec<_>>();
+
+    let cartesian_points = sine_products
+        .zip(cosines.iter())
+        .map(|(sine_product, &cosine)| sine_product * cosine * radius)
+        .collect::<Vec<_>>();
+
+    cartesian_points
 }

--- a/crates/SyMaGen/src/random_data.rs
+++ b/crates/SyMaGen/src/random_data.rs
@@ -1,9 +1,41 @@
 //! Generate random data for use in benchmarks and tests.
 
-use distances::number::{Float, Int};
+use distances::number::Number;
 use rand::prelude::*;
 
-/// Generate a randomized tabular dataset of integers for use in benchmarks and tests.
+/// The mathematical constant π.
+pub const PI: f64 = std::f64::consts::PI;
+
+/// Generate a randomized tabular dataset for use in benchmarks and tests with a
+/// given seed.
+///
+/// This uses the `rand` crate's `StdRng` as the random number generator.
+///
+/// # Arguments:
+///
+/// * `cardinality`: number of points to generate.
+/// * `dimensionality`: dimensionality of points to generate.
+/// * `min_val`: of each axis in the hypercube.
+/// * `max_val`: of each axis in the hypercube.
+/// * `seed`: for the random number generator.
+#[must_use]
+pub fn random_tabular_seedable<T: Number>(
+    cardinality: usize,
+    dimensionality: usize,
+    min_val: T,
+    max_val: T,
+    seed: u64,
+) -> Vec<Vec<T>> {
+    random_tabular(
+        cardinality,
+        dimensionality,
+        min_val,
+        max_val,
+        &mut rand::rngs::StdRng::seed_from_u64(seed),
+    )
+}
+
+/// Generate a randomized tabular dataset for use in benchmarks and tests.
 ///
 /// # Arguments:
 ///
@@ -13,7 +45,7 @@ use rand::prelude::*;
 /// * `max_val`: of each axis in the hypercube.
 /// * `rng`: random number generator.
 #[must_use]
-pub fn random_tabular_integers<T: Int, R: Rng>(
+pub fn random_tabular<T: Number, R: Rng>(
     cardinality: usize,
     dimensionality: usize,
     min_val: T,
@@ -25,33 +57,6 @@ pub fn random_tabular_integers<T: Int, R: Rng>(
         .map(|_| {
             (0..dimensionality)
                 .map(|_| min_val + T::next_random(rng) % diff)
-                .collect()
-        })
-        .collect()
-}
-
-/// Generate a randomized tabular dataset of floats for use in benchmarks and tests.
-///
-/// # Arguments:
-///
-/// * `cardinality`: number of points to generate.
-/// * `dimensionality`: dimensionality of points to generate.
-/// * `min_val`: of each axis in the hypercube.
-/// * `max_val`: of each axis in the hypercube.
-/// * `rng`: random number generator.
-#[must_use]
-pub fn random_tabular_floats<T: Float, R: Rng>(
-    cardinality: usize,
-    dimensionality: usize,
-    min_val: T,
-    max_val: T,
-    rng: &mut R,
-) -> Vec<Vec<T>> {
-    let diff = max_val - min_val;
-    (0..cardinality)
-        .map(|_| {
-            (0..dimensionality)
-                .map(|_| min_val + T::next_random(rng) * diff)
                 .collect()
         })
         .collect()
@@ -78,4 +83,21 @@ pub fn random_string(cardinality: usize, min_len: usize, max_len: usize, alphabe
                 .collect::<String>()
         })
         .collect()
+}
+
+/// Generate a single point (in Cartesian coordinates) from a uniform distribution over an n-dimensional ball of given radius.
+///
+/// # Arguments:
+///
+/// * `dim`: dimensionality of the point to generate
+/// * `radius`: radius of the ball
+/// * `rng`: random number generator
+///
+/// # Returns:
+///
+/// * `Vec<T>`: the generated point
+pub fn n_ball<T: Number, R: Rng>(dim: usize, _radius: f64, rng: &mut R) -> Vec<T> {
+    let _angles: Vec<T> = (0..dim).map(|_| T::next_random(rng) % T::from(PI)).collect();
+
+    [T::from(0.1)].to_vec()
 }

--- a/crates/SyMaGen/src/random_data.rs
+++ b/crates/SyMaGen/src/random_data.rs
@@ -96,10 +96,8 @@ pub fn random_string(cardinality: usize, min_len: usize, max_len: usize, alphabe
 /// # Returns:
 ///
 /// * `Vec<T>`: the generated point
-pub fn n_ball<R: Rng>(_dim: usize, radius: f64, _rng: &mut R) -> Vec<f64> {
-    // let _angles: Vec<f64> = (0..dim).map(|_| f64::next_random(rng) % f64::from(PI)).collect();
-    // let angles = random_tabular(1,dim, 0, 2.*PI,  &mut 42);
-    let angles = [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
+pub fn n_ball<R: Rng>(dim: usize, radius: f64, rng: &mut R) -> Vec<f64> {
+    let angles: Vec<f64> = (0..dim).map(|_| f64::next_random(rng) % (2. * PI)).collect();
 
     let sine_products = angles.iter().scan(1., |sine_product, &x| {
         // each iteration, we'll multiply the state by the element ...

--- a/crates/SyMaGen/tests/test_ball.rs
+++ b/crates/SyMaGen/tests/test_ball.rs
@@ -1,0 +1,34 @@
+//! Tests for random data generation within a ball.
+
+use rand::SeedableRng;
+use symagen::random_data::n_ball;
+
+fn l2_norm(data: &[f64]) -> f64 {
+    data.iter().map(|x| x * x).sum::<f64>().sqrt()
+}
+
+#[test]
+fn tiny() {
+    let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+    for r in 0..3 {
+        let radius = 10.0_f64.powi(r);
+        for dim in 2..=10 {
+            let data = n_ball(dim, radius, &mut rng);
+            assert_eq!(data.len(), dim);
+            assert!(l2_norm(&data) <= radius);
+        }
+    }
+}
+
+#[test]
+fn large() {
+    let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+    for r in 0..3 {
+        let radius = 10.0_f64.powi(r);
+        for dim in (100..1_000_000).step_by(10_000) {
+            let data = n_ball(dim, radius, &mut rng);
+            assert_eq!(data.len(), dim);
+            assert!(l2_norm(&data) <= radius);
+        }
+    }
+}

--- a/crates/abd-clam/README.md
+++ b/crates/abd-clam/README.md
@@ -33,7 +33,7 @@ let seed = 42;
 let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
 let (cardinality, dimensionality) = (1_000, 10);
 let (min_val, max_val) = (-1.0, 1.0);
-let data: Vec<Vec<f32>> = symagen::random_data::random_tabular_floats(
+let data: Vec<Vec<f32>> = symagen::random_data::random_tabular(
     cardinality,
     dimensionality,
     min_val,

--- a/crates/abd-clam/benches/knn-search.rs
+++ b/crates/abd-clam/benches/knn-search.rs
@@ -21,7 +21,7 @@ fn cakes(c: &mut Criterion) {
     let (cardinality, dimensionality) = (100_000, 10);
     let (min_val, max_val) = (-1., 1.);
 
-    let data = random_data::random_tabular_floats(
+    let data = random_data::random_tabular(
         cardinality,
         dimensionality,
         min_val,

--- a/crates/abd-clam/benches/knn-vs-rnn.rs
+++ b/crates/abd-clam/benches/knn-vs-rnn.rs
@@ -18,7 +18,7 @@ fn cakes(c: &mut Criterion) {
     let (cardinality, dimensionality) = (1_000_000, 10);
     let (min_val, max_val) = (-1., 1.);
 
-    let data = random_data::random_tabular_floats(
+    let data = random_data::random_tabular(
         cardinality,
         dimensionality,
         min_val,
@@ -27,7 +27,7 @@ fn cakes(c: &mut Criterion) {
     );
 
     let num_queries = 100;
-    let queries = random_data::random_tabular_floats(
+    let queries = random_data::random_tabular(
         num_queries,
         dimensionality,
         min_val,

--- a/crates/abd-clam/benches/rnn-search.rs
+++ b/crates/abd-clam/benches/rnn-search.rs
@@ -16,7 +16,7 @@ fn cakes(c: &mut Criterion) {
     let (cardinality, dimensionality) = (1_000_000, 10);
     let (min_val, max_val) = (-1., 1.);
 
-    let data = random_data::random_tabular_floats(
+    let data = random_data::random_tabular(
         cardinality,
         dimensionality,
         min_val,
@@ -25,7 +25,7 @@ fn cakes(c: &mut Criterion) {
     );
 
     let num_queries = 100;
-    let queries = random_data::random_tabular_floats(
+    let queries = random_data::random_tabular(
         num_queries,
         dimensionality,
         min_val,

--- a/crates/abd-clam/src/cakes/sharded.rs
+++ b/crates/abd-clam/src/cakes/sharded.rs
@@ -227,7 +227,7 @@ mod tests {
         let (cardinality, dimensionality) = (10_000, 10);
         let (min_val, max_val) = (-1., 1.);
 
-        let data_vec = random_data::random_tabular_floats(
+        let data_vec = random_data::random_tabular(
             cardinality,
             dimensionality,
             min_val,
@@ -236,7 +236,7 @@ mod tests {
         );
 
         let num_queries = 100;
-        let queries = random_data::random_tabular_floats(
+        let queries = random_data::random_tabular(
             num_queries,
             dimensionality,
             min_val,

--- a/crates/abd-clam/src/core/graph/_graph.rs
+++ b/crates/abd-clam/src/core/graph/_graph.rs
@@ -778,7 +778,7 @@ mod tests {
         metric: fn(&Vec<f32>, &Vec<f32>) -> f32,
     ) -> VecDataset<Vec<f32>, f32, usize> {
         let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
-        let data = symagen::random_data::random_tabular_floats(cardinality, dimensionality, -1., 1., &mut rng);
+        let data = symagen::random_data::random_tabular(cardinality, dimensionality, -1., 1., &mut rng);
         let name = "test".to_string();
         VecDataset::new(name, data, metric, false)
     }

--- a/crates/abd-clam/src/core/graph/criteria.rs
+++ b/crates/abd-clam/src/core/graph/criteria.rs
@@ -174,7 +174,7 @@ mod tests {
         metric: fn(&Vec<f32>, &Vec<f32>) -> f32,
     ) -> VecDataset<Vec<f32>, f32, usize> {
         let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
-        let data = symagen::random_data::random_tabular_floats(cardinality, dimensionality, -1., 1., &mut rng);
+        let data = symagen::random_data::random_tabular(cardinality, dimensionality, -1., 1., &mut rng);
         let name = "test".to_string();
         VecDataset::new(name, data, metric, false)
     }

--- a/crates/abd-clam/src/utils.rs
+++ b/crates/abd-clam/src/utils.rs
@@ -414,7 +414,7 @@ mod tests {
 
         // Generate random data for each cardinality and min/max value where max_val > min_val
         for (cardinality, (min_val, max_val)) in cardinalities.into_iter().zip(ranges.into_iter()) {
-            let data = random_data::random_tabular_floats(
+            let data = random_data::random_tabular(
                 dimensionality,
                 cardinality,
                 min_val,

--- a/crates/abd-clam/tests/test_dataset.rs
+++ b/crates/abd-clam/tests/test_dataset.rs
@@ -13,7 +13,7 @@ fn reordering() {
     let dimensionality = 10;
 
     for i in 0..10 {
-        let reference_data = symagen::random_data::random_tabular_integers(
+        let reference_data = symagen::random_data::random_tabular(
             cardinality,
             dimensionality,
             0,
@@ -86,7 +86,7 @@ fn save_load(cardinality: usize, dimensionality: usize) {
     let tmp_dir = TempDir::new("save_load_deterministic").unwrap();
 
     for i in 0..5 {
-        let reference_data = symagen::random_data::random_tabular_integers(
+        let reference_data = symagen::random_data::random_tabular(
             cardinality,
             dimensionality,
             0,

--- a/crates/abd-clam/tests/utils.rs
+++ b/crates/abd-clam/tests/utils.rs
@@ -44,7 +44,7 @@ pub fn gen_dataset(
     metric: fn(&Vec<f32>, &Vec<f32>) -> f32,
 ) -> VecDataset<Vec<f32>, f32, usize> {
     let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
-    let data = symagen::random_data::random_tabular_floats(cardinality, dimensionality, -1., 1., &mut rng);
+    let data = symagen::random_data::random_tabular(cardinality, dimensionality, -1., 1., &mut rng);
     let name = "test".to_string();
     VecDataset::new(name, data, metric, false)
 }

--- a/crates/cakes-results/src/ann_datasets.rs
+++ b/crates/cakes-results/src/ann_datasets.rs
@@ -130,14 +130,14 @@ impl AnnDatasets {
             let seed = 42;
             let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
 
-            let train_data = symagen::random_data::random_tabular_floats(
+            let train_data = symagen::random_data::random_tabular(
                 1_000_000,
                 dimensionality,
                 min_val,
                 max_val,
                 &mut rng,
             );
-            let test_data = symagen::random_data::random_tabular_floats(
+            let test_data = symagen::random_data::random_tabular(
                 10_000,
                 dimensionality,
                 min_val,

--- a/crates/distances/benches/big-lp.rs
+++ b/crates/distances/benches/big-lp.rs
@@ -42,7 +42,7 @@ fn big_lp_norms(c: &mut Criterion) {
 
     for d in 2..=7 {
         let dimensionality = 10_u32.pow(d) as usize;
-        let data = random_data::random_tabular_floats(
+        let data = random_data::random_tabular(
             cardinality,
             dimensionality,
             min_val,

--- a/crates/distances/benches/big-vectors.rs
+++ b/crates/distances/benches/big-vectors.rs
@@ -39,7 +39,7 @@ fn big_f32(c: &mut Criterion) {
 
     for d in 2..=7 {
         let dimensionality = 10_u32.pow(d) as usize;
-        let data = random_data::random_tabular_floats(
+        let data = random_data::random_tabular(
             cardinality,
             dimensionality,
             min_val,
@@ -71,7 +71,7 @@ fn big_u32(c: &mut Criterion) {
 
     for d in 2..=7 {
         let dimensionality = 10_u32.pow(d) as usize;
-        let data = random_data::random_tabular_integers(
+        let data = random_data::random_tabular(
             cardinality,
             dimensionality,
             min_val,

--- a/crates/distances/benches/inv-sqrt.rs
+++ b/crates/distances/benches/inv-sqrt.rs
@@ -6,7 +6,7 @@ use distances::number::Float;
 
 /// Generates a vec of 10 million random non-negative f32s
 fn gen_f32s() -> Vec<Vec<f32>> {
-    random_data::random_tabular_floats(
+    random_data::random_tabular(
         1,
         10_000_000,
         0.0,
@@ -17,7 +17,7 @@ fn gen_f32s() -> Vec<Vec<f32>> {
 
 /// Generates a vec of 10 million random non-negative f64s
 fn gen_f64s() -> Vec<Vec<f64>> {
-    random_data::random_tabular_floats(
+    random_data::random_tabular(
         1,
         10_000_000,
         0.0,

--- a/crates/distances/benches/simd-cosine.rs
+++ b/crates/distances/benches/simd-cosine.rs
@@ -13,7 +13,7 @@ fn simd_f32(c: &mut Criterion) {
 
     for d in 0..=5 {
         let dimensionality = 1_000 * 2_u32.pow(d) as usize;
-        let vecs = random_data::random_tabular_floats(
+        let vecs = random_data::random_tabular(
             cardinality,
             dimensionality,
             min_val,
@@ -41,7 +41,7 @@ fn simd_f64(c: &mut Criterion) {
 
     for d in 0..=5 {
         let dimensionality = 1_000 * 2_u32.pow(d) as usize;
-        let vecs = random_data::random_tabular_floats(
+        let vecs = random_data::random_tabular(
             cardinality,
             dimensionality,
             min_val,

--- a/crates/distances/benches/simd-euclidean.rs
+++ b/crates/distances/benches/simd-euclidean.rs
@@ -13,7 +13,7 @@ fn simd_f32(c: &mut Criterion) {
 
     for d in 0..=5 {
         let dimensionality = 1_000 * 2_u32.pow(d) as usize;
-        let vecs = random_data::random_tabular_floats(
+        let vecs = random_data::random_tabular(
             cardinality,
             dimensionality,
             min_val,
@@ -51,7 +51,7 @@ fn simd_f64(c: &mut Criterion) {
 
     for d in 0..=5 {
         let dimensionality = 1_000 * 2_u32.pow(d) as usize;
-        let vecs = random_data::random_tabular_floats(
+        let vecs = random_data::random_tabular(
             cardinality,
             dimensionality,
             min_val,

--- a/crates/distances/src/simd/mod.rs
+++ b/crates/distances/src/simd/mod.rs
@@ -251,7 +251,7 @@ mod test {
         let input_sizes = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024];
 
         for i in input_sizes {
-            let data = random_data::random_tabular_floats(
+            let data = random_data::random_tabular(
                 2,
                 i,
                 -10_f32,

--- a/crates/distances/tests/test_float.rs
+++ b/crates/distances/tests/test_float.rs
@@ -5,7 +5,7 @@ use distances::number::Float;
 
 /// Generates a vec of 10 million random non-negative f32s
 fn gen_f32s() -> Vec<Vec<f32>> {
-    random_data::random_tabular_floats(
+    random_data::random_tabular(
         1,
         10_000_000,
         -1e10_f32,
@@ -16,7 +16,7 @@ fn gen_f32s() -> Vec<Vec<f32>> {
 
 /// Generates a vec of 10 million random non-negative f64s
 fn gen_f64s() -> Vec<Vec<f64>> {
-    random_data::random_tabular_floats(
+    random_data::random_tabular(
         1,
         10_000_000,
         -1e10_f64,

--- a/crates/distances/tests/test_simd.rs
+++ b/crates/distances/tests/test_simd.rs
@@ -22,9 +22,9 @@ fn simd_distances_f32(
     let mut rng = rand::thread_rng();
 
     let data_x =
-        random_data::random_tabular_floats(cardinality, dimensionality, min_val, max_val, &mut rng);
+        random_data::random_tabular(cardinality, dimensionality, min_val, max_val, &mut rng);
     let data_y =
-        random_data::random_tabular_floats(cardinality, dimensionality, min_val, max_val, &mut rng);
+        random_data::random_tabular(cardinality, dimensionality, min_val, max_val, &mut rng);
     let mut failures = Vec::new();
 
     for (i, x) in data_x.iter().enumerate() {
@@ -63,9 +63,9 @@ fn simd_distances_f64(
     let mut rng = rand::thread_rng();
 
     let data_x =
-        random_data::random_tabular_floats(cardinality, dimensionality, min_val, max_val, &mut rng);
+        random_data::random_tabular(cardinality, dimensionality, min_val, max_val, &mut rng);
     let data_y =
-        random_data::random_tabular_floats(cardinality, dimensionality, min_val, max_val, &mut rng);
+        random_data::random_tabular(cardinality, dimensionality, min_val, max_val, &mut rng);
     let mut failures = Vec::new();
 
     for (i, x) in data_x.iter().enumerate() {

--- a/crates/distances/tests/test_vectors_f32.rs
+++ b/crates/distances/tests/test_vectors_f32.rs
@@ -48,7 +48,7 @@ fn lp_f32() {
     let (cardinality, dimensionality) = (100, 10_000);
     let (min_val, max_val) = (-10., 10.);
 
-    let data = random_data::random_tabular_floats(
+    let data = random_data::random_tabular(
         cardinality,
         dimensionality,
         min_val,

--- a/crates/distances/tests/test_vectors_u32.rs
+++ b/crates/distances/tests/test_vectors_u32.rs
@@ -58,7 +58,7 @@ fn lp_u32() {
     let (cardinality, dimensionality) = (100, 10_000);
     let (min_val, max_val) = (0, 10_000);
 
-    let data = random_data::random_tabular_integers(
+    let data = random_data::random_tabular(
         cardinality,
         dimensionality,
         min_val,


### PR DESCRIPTION
Implemented function to generate a random point (in Cartesian coordinates) from a uniform distribution over an n-dimensional ball of a given radius. The math used is derived from [this wikipedia article](https://en.wikipedia.org/wiki/N-sphere#Spherical_coordinates). The algorithm here is linear-time in the dimensionality of the point being generated.

Some comments: 
- We've had errors with functions in Symagen before, so I think we should think about a better way to test this stuff going forward (I know this is difficult because of the randomness) 
-  Right now this is implemented for f64s; is that okay or should it be more generic? 
