### PR TITLE
Kulsinski distance, set tests added

### DIFF
--- a/crates/distances/README.md
+++ b/crates/distances/README.md
@@ -67,6 +67,8 @@ assert!((distance - (27.0_f32).sqrt()).abs() < 1e-6);
   - [ ] Normalized versions of the above.
 - [ ] Sets:
   - [x] `jaccard`
+  - [x] `dice`
+  - [x] `kulsinski`
   - [ ] `hausdorff`
     - [Hausdorff Distance](https://en.wikipedia.org/wiki/Hausdorff_distance)
 - [ ] Graphs:

--- a/crates/distances/src/sets/mod.rs
+++ b/crates/distances/src/sets/mod.rs
@@ -91,8 +91,14 @@ pub fn dice<T: Int, U: Float>(x: &[T], y: &[T]) -> U {
 /// Kulsinski distance.
 ///
 /// Similar to the Jaccard distance, the Kulsinski distance is a measure of the dissimilarity
-/// between two sets. It is defined as the cardinality of the intersection divided by the
-/// sum of the number of not equal dimensions and the total number of dimensions.
+/// between two sets. It is defined as the sum of the number of not equal dimensions and the
+/// total number of dimensions minus the number of elements in the intersection, all divided by
+/// the sum of the number of not equal dimensions and the total number of dimensions.
+///
+/// # Links
+///
+/// <https://scikit-learn.org/stable/modules/generated/sklearn.metrics.DistanceMetric.html>
+/// <https://docs.scipy.org/doc/scipy-1.7.1/reference/reference/generated/scipy.spatial.distance.kulsinski.html>
 ///
 /// # Arguments
 ///

--- a/crates/distances/src/sets/mod.rs
+++ b/crates/distances/src/sets/mod.rs
@@ -87,3 +87,46 @@ pub fn dice<T: Int, U: Float>(x: &[T], y: &[T]) -> U {
 
     U::one() - (U::from(2) * intersection_size / size)
 }
+
+/// Kulsinski distance.
+///
+/// Similar to the Jaccard distance, the Kulsinski distance is a measure of the dissimilarity
+/// between two sets. It is defined as the cardinality of the intersection divided by the
+/// sum of the number of not equal dimensions and the total number of dimensions.
+///
+/// # Arguments
+///
+/// * `x`: A set represented as a slice of `Int`s, i.e. a type generic over integers.
+/// * `y`: A set represented as a slice of `Int`s, i.e. a type generic over integers.
+///
+/// # Examples
+///
+/// ```
+/// use distances::sets::kulsinski;
+///
+/// let x: Vec<u32> = vec![1, 2, 3];
+/// let y: Vec<u32> = vec![2, 3, 4];
+///
+/// let distance: f32 = kulsinski(&x, &y);
+/// let real_distance: f32 = 2_f32 / 3_f32;
+///
+/// assert!((distance - real_distance).abs() < f32::EPSILON);
+/// ```
+pub fn kulsinski<T: Int, U: Float>(x: &[T], y: &[T]) -> U {
+    if x.is_empty() || y.is_empty() {
+        return U::one();
+    }
+
+    let x = x.iter().copied().collect::<BTreeSet<_>>();
+    let y = y.iter().copied().collect::<BTreeSet<_>>();
+
+    let intersection = x.intersection(&y).count();
+    let union = x.union(&y).count();
+    let not_equal = union - intersection;
+
+    if intersection == x.len() && intersection == y.len() {
+        U::zero()
+    } else {
+        U::one() - (U::from(intersection) / U::from(union + not_equal))
+    }
+}

--- a/crates/distances/tests/test_sets.rs
+++ b/crates/distances/tests/test_sets.rs
@@ -47,43 +47,43 @@ fn sets_test() {
     for _ in 0..10000 {
         let x: Vec<u16> = gen_set();
         let y: Vec<u16> = gen_set();
-        let mut union: f32 = 0.0;
-        let mut intersection: f32 = 0.0;
-        let mut size: f32 = 0.0;
+        let mut union: usize = 0;
+        let mut intersection: usize = 0;
+        let mut size: usize = 0;
         for i in 0_u16..1000 {
             if x.contains(&i) || y.contains(&i) {
-                union += 1.0;
-                size += 1.0;
+                union += 1;
+                size += 1;
             }
             if x.contains(&i) && y.contains(&i) {
-                intersection += 1.0;
-                size += 1.0;
+                intersection += 1;
+                size += 1;
             }
         }
         let mut distance: f32;
         let mut real_distance: f32;
 
         distance = jaccard(&x, &y);
-        if union == 0.0 {
+        if union == 0 {
             real_distance = 0.0;
         } else {
-            real_distance = 1_f32 - intersection / union;
+            real_distance = 1_f32 - (intersection as f32) / (union as f32);
         }
         assert!((distance - real_distance).abs() < f32::EPSILON);
 
         distance = dice(&x, &y);
-        if union == 0.0 {
+        if union == 0 {
             real_distance = 0.0;
         } else {
-            real_distance = 1_f32 - (2_f32 * (intersection / size));
+            real_distance = 1_f32 - (2_f32 * ((intersection as f32) / (size as f32)));
         }
         assert!((distance - real_distance).abs() < f32::EPSILON);
 
         distance = kulsinski(&x, &y);
-        if union == 0.0 {
+        if union == 0 {
             real_distance = 0.0;
         } else {
-            real_distance = 1_f32 - intersection / (union + union - intersection);
+            real_distance = 1_f32 - (intersection as f32) / ((union + union - intersection) as f32);
         }
         assert!((distance - real_distance).abs() < f32::EPSILON);
     }

--- a/crates/distances/tests/test_sets.rs
+++ b/crates/distances/tests/test_sets.rs
@@ -1,4 +1,6 @@
 use distances::sets::dice;
+use distances::sets::jaccard;
+use distances::sets::kulsinski;
 
 #[test]
 #[allow(clippy::float_equality_without_abs)]
@@ -26,4 +28,93 @@ fn test_dice() {
 
     let distance: f32 = dice(&x, &y);
     assert!((distance - 0.8) < f32::EPSILON);
+}
+
+/// Generates a length 1000 set with each bit flipped randomly on or off
+fn gen_set() -> Vec<u16> {
+    let mut vec = Vec::new();
+    for i in 0..1000 {
+        if rand::random() {
+            vec.push(i);
+        }
+    }
+    vec
+}
+
+/// Random exhaustive testing of set distances, manually creating union and intersection values
+#[test]
+fn sets_test() {
+    for _ in 0..10000 {
+        let x: Vec<u16> = gen_set();
+        let y: Vec<u16> = gen_set();
+        let mut union: f32 = 0.0;
+        let mut intersection: f32 = 0.0;
+        let mut size: f32 = 0.0;
+        for i in 0_u16..1000 {
+            if x.contains(&i) || y.contains(&i) {
+                union += 1.0;
+                size += 1.0;
+            }
+            if x.contains(&i) && y.contains(&i) {
+                intersection += 1.0;
+                size += 1.0;
+            }
+        }
+        let mut distance: f32;
+        let mut real_distance: f32;
+
+        distance = jaccard(&x, &y);
+        if union == 0.0 {
+            real_distance = 0.0;
+        } else {
+            real_distance = 1_f32 - intersection / union;
+        }
+        assert!((distance - real_distance).abs() < f32::EPSILON);
+
+        distance = dice(&x, &y);
+        if union == 0.0 {
+            real_distance = 0.0;
+        } else {
+            real_distance = 1_f32 - (2_f32 * (intersection / size));
+        }
+        assert!((distance - real_distance).abs() < f32::EPSILON);
+
+        distance = kulsinski(&x, &y);
+        if union == 0.0 {
+            real_distance = 0.0;
+        } else {
+            real_distance = 1_f32 - intersection / (union + union - intersection);
+        }
+        assert!((distance - real_distance).abs() < f32::EPSILON);
+    }
+}
+
+/// Boundary testing for set distances, equal sets or one zero set
+#[test]
+fn bounds_test() {
+    let x: Vec<u16> = gen_set();
+    let y: Vec<u16> = Vec::new();
+
+    let mut distance: f32;
+
+    distance = jaccard(&x, &x);
+    assert!(distance < f32::EPSILON);
+    distance = jaccard(&x, &y);
+    assert!(distance - 1.0 < f32::EPSILON);
+    distance = jaccard(&y, &y);
+    assert!(distance - 1.0 < f32::EPSILON);
+
+    distance = dice(&x, &x);
+    assert!(distance < f32::EPSILON);
+    distance = dice(&x, &y);
+    assert!(distance - 1.0 < f32::EPSILON);
+    distance = dice(&y, &y);
+    assert!(distance - 1.0 < f32::EPSILON);
+
+    distance = kulsinski(&x, &x);
+    assert!(distance < f32::EPSILON);
+    distance = kulsinski(&x, &y);
+    assert!(distance - 1.0 < f32::EPSILON);
+    distance = kulsinski(&y, &y);
+    assert!(distance - 1.0 < f32::EPSILON);
 }


### PR DESCRIPTION
I coded in Kulsinksi distance in the same file as Jaccard distance using the same format, relatively self explanatory.
I also added a test_sets.rs file to the tests folder, which contains tests for the Jaccard and Kulsinski distances and can easily be added to. I use random exhaustive testing, creating two 1000 length sets with each number randomly swapped to be on or off. I then check if each function gives the intended result finding distance between the two.
I then have some checks of edge cases, with one or both sets being empty or both sets being the same.
Both of these testing methods are easily addable to once a new set distance function is added.
I also added and checked off Kulsinski distance in the ReadMe.

I also added Dice distance into the ReadMe, and added Dice distance into my tests when moving my code from distances to clam. Even though there were already Dice tests, I added Dice into my own as well in order to be encompassing.