### PR TITLE
fix(release): reorder crates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.repository == 'URI-ABD/clam'
     strategy:
       matrix:
-        package: [abd-clam, distances, SyMaGen]
+        package: [distances, SyMaGen, abd-clam]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
I think the failure to publish on master comes down to not having run `distances` publish step first. This PR re-orders the CI matrix such that `distances` is published before we attempt to publish other packages. 