### PR TITLE
Implemented edit functions

### DIFF
--- a/crates/distances/src/strings/needleman_wunsch/helpers.rs
+++ b/crates/distances/src/strings/needleman_wunsch/helpers.rs
@@ -349,6 +349,19 @@ pub fn aligned_x_to_y(x: &str, y: &str) -> Vec<Edit> {
     aligned_x_to_y
 }
 
+/// Given two unaligned strings, returns the edits related to gaps to align the 2 strings.
+///
+/// Requires that gaps are never aligned with gaps (our NW implementation with the default penalties ensures this).
+/// Uses the "traceback_iterative" ftn to align the strings.
+///
+/// # Arguments
+///
+/// * `x`: A unaligned string.
+/// * `y`: A unaligned string.
+///
+/// # Returns
+///
+/// A vector of edits to transform the aligned version of `x` into the aligned version of `y` excluding substitutions.
 pub fn aligned_x_to_y_no_sub(x: &str, y: &str) -> Vec<Edit> {
     let table = compute_table::<u16>(x, y, Penalties::default());
     let (aligned_x, aligned_y) = trace_back_iterative(&table, [x,y]);
@@ -372,6 +385,19 @@ pub fn aligned_x_to_y_no_sub(x: &str, y: &str) -> Vec<Edit> {
     aligned_x_to_y
 }
 
+/// Given two unaligned strings, returns the location of the gaps needed to align the 2 strings.
+///
+/// Requires that gaps are never aligned with gaps (our NW implementation with the default penalties ensures this).
+/// Uses the "traceback_iterative" ftn to align the strings.
+///
+/// # Arguments
+///
+/// * `x`: A unaligned string.
+/// * `y`: A unaligned string.
+///
+/// # Returns
+///
+/// An array of 2 vectors of edits to align `x` and `y`.
 pub fn x_to_y_alignment(x: &str, y: &str) -> [Vec<usize>; 2] {
     let table = compute_table::<u16>(x, y, Penalties::default());
     let (aligned_x, aligned_y) = trace_back_iterative(&table, [x,y]);

--- a/crates/distances/src/strings/needleman_wunsch/helpers.rs
+++ b/crates/distances/src/strings/needleman_wunsch/helpers.rs
@@ -416,6 +416,7 @@ pub fn x_to_y_alignment(x: &str, y: &str) -> [Vec<usize>; 2] {
             } else if c_y == '-' {
                 gap_indices[1].push(index);
                 modifier += 1;
+                
             }         
     });
     gap_indices
@@ -572,6 +573,7 @@ mod tests {
                                                 inserts.remove(0);},
                 _ => assert_eq!(0, 1),
             }
+            
         }
 
 


### PR DESCRIPTION
- Fixed small bug in alignment function
- Added the "aligned_x_to_y_no_sub" function to collect the edits needed to align one sequence to another (ignoring substitutions)
- Added the "x_to_y_alignment" function to collect the indices of the gaps needed to align one sequence to another 
- Added one test to ensure everything works